### PR TITLE
feat: Naver News API  Batch Processor, Writer 구현

### DIFF
--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/batch/BatchArticleWriter.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/batch/BatchArticleWriter.java
@@ -1,0 +1,28 @@
+package com.codeit.team2.monew.module.domain.article.batch;
+
+import com.codeit.team2.monew.module.domain.article.entity.Article;
+import com.codeit.team2.monew.module.domain.article.repository.ArticleRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BatchArticleWriter implements ItemWriter<List<Article>> {
+
+    private final ArticleRepository articleRepository;
+
+    @Override
+    public void write(Chunk<? extends List<Article>> items) throws Exception {
+        List<Article> flatList = new ArrayList<>();
+
+        for (List<Article> list : items) {
+            flatList.addAll(list);
+        }
+
+        articleRepository.saveAll(flatList);
+    }
+}

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/batch/KeywordToArticlesProcessor.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/batch/KeywordToArticlesProcessor.java
@@ -1,0 +1,40 @@
+package com.codeit.team2.monew.module.domain.article.batch;
+
+import com.codeit.team2.monew.module.domain.article.dto.FetchCommand;
+import com.codeit.team2.monew.module.domain.article.entity.Article;
+import com.codeit.team2.monew.module.domain.article.external.NaverNewsClient;
+import com.codeit.team2.monew.module.domain.interest.entity.Keyword;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class KeywordToArticlesProcessor implements ItemProcessor<Keyword, List<Article>> {
+
+    private final NaverNewsClient naverNewsClient;
+
+    @Override
+    public List<Article> process(Keyword keyword) throws Exception {
+        List<Article> allArticles = new ArrayList<>();
+        int start = 1;
+        int display = 100;
+
+        while (start <= 1000) {
+            FetchCommand cmd = new FetchCommand(keyword.getName(), display, start, "date");
+            List<Article> articles = naverNewsClient.fetchArticles(cmd);
+
+            if (articles.isEmpty() || articles.size() < display) {
+                allArticles.addAll(articles);
+                break;
+            }
+
+            allArticles.addAll(articles);
+            start += display;
+        }
+
+        return allArticles;
+    }
+}

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/repository/ArticleRepository.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/repository/ArticleRepository.java
@@ -1,0 +1,9 @@
+package com.codeit.team2.monew.module.domain.article.repository;
+
+import com.codeit.team2.monew.module.domain.article.entity.Article;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleRepository extends JpaRepository<Article, UUID> {
+
+}

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/entity/Keyword.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/entity/Keyword.java
@@ -5,9 +5,11 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@AllArgsConstructor
 @Entity
 @Table(name = "keywords")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/article/batch/ArticleBatchItemReaderTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/article/batch/ArticleBatchItemReaderTest.java
@@ -1,0 +1,17 @@
+package com.codeit.team2.monew.module.domain.article.batch;
+
+// TODO : Keyword repository 완료시 작업
+//
+//@JdbcTest
+//@Import({KeywordReaderConfig.class})
+//public class ArticleBatchItemReaderTest {
+//
+//
+//    @Autowired
+//    private JdbcPagingItemReader<Keyword> keywordReader;
+//
+//    @Test
+//    void keywordReader_shouldReturn_keywords() {
+//
+//    }
+//}

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/article/batch/BatchArticleWriterTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/article/batch/BatchArticleWriterTest.java
@@ -1,0 +1,53 @@
+package com.codeit.team2.monew.module.domain.article.batch;
+
+import com.codeit.team2.monew.module.domain.article.entity.Article;
+import com.codeit.team2.monew.module.domain.article.repository.ArticleRepository;
+import java.time.Instant;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class BatchArticleWriterTest {
+
+    @Mock
+    private ArticleRepository articleRepository;
+
+    private BatchArticleWriter writer;
+
+    @BeforeEach
+    void setup() {
+        writer = new BatchArticleWriter(articleRepository);
+    }
+
+
+    @Test
+    void testWriteToRepository_success() {
+        //given
+        List<Article> articles1 = List.of(
+            new Article("a", "a", "a", "a", 0, Instant.now(), false),
+            new Article("b", "b", "b", "b", 0, Instant.now(), false)
+        );
+
+        List<Article> articles2 = List.of(
+            new Article("c", "c", "c", "c", 0, Instant.now(), false),
+            new Article("d", "d", "d", "d", 0, Instant.now(), false)
+        );
+
+        List<List<Article>> combined = List.of(articles1, articles2);
+
+        //when
+        writer.write(combined);
+
+        // then
+        ArgumentCaptor<List<Article>> captor = ArgumentCaptor.forClass(List.class);
+
+        List<Article> flatList = captor.getValue();
+        Assertions.assertThat(flatList).hasSize(4);
+    }
+}

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/article/batch/BatchArticleWriterTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/article/batch/BatchArticleWriterTest.java
@@ -1,5 +1,7 @@
 package com.codeit.team2.monew.module.domain.article.batch;
 
+import static org.mockito.BDDMockito.then;
+
 import com.codeit.team2.monew.module.domain.article.entity.Article;
 import com.codeit.team2.monew.module.domain.article.repository.ArticleRepository;
 import java.time.Instant;
@@ -11,6 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.item.Chunk;
 
 @ExtendWith(MockitoExtension.class)
 public class BatchArticleWriterTest {
@@ -27,7 +30,7 @@ public class BatchArticleWriterTest {
 
 
     @Test
-    void testWriteToRepository_success() {
+    void testWriteToRepository_success() throws Exception {
         //given
         List<Article> articles1 = List.of(
             new Article("a", "a", "a", "a", 0, Instant.now(), false),
@@ -39,13 +42,15 @@ public class BatchArticleWriterTest {
             new Article("d", "d", "d", "d", 0, Instant.now(), false)
         );
 
-        List<List<Article>> combined = List.of(articles1, articles2);
+        Chunk<List<Article>> combined = new Chunk(List.of(articles1, articles2));
 
         //when
         writer.write(combined);
 
         // then
         ArgumentCaptor<List<Article>> captor = ArgumentCaptor.forClass(List.class);
+        
+        then(articleRepository).should().saveAll(captor.capture());
 
         List<Article> flatList = captor.getValue();
         Assertions.assertThat(flatList).hasSize(4);

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/article/batch/KeywordToArticlesProcessorTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/article/batch/KeywordToArticlesProcessorTest.java
@@ -1,6 +1,7 @@
 package com.codeit.team2.monew.module.domain.article.batch;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
 
 import com.codeit.team2.monew.module.domain.article.entity.Article;
 import com.codeit.team2.monew.module.domain.article.external.NaverNewsClient;
@@ -29,7 +30,7 @@ public class KeywordToArticlesProcessorTest {
     }
 
     @Test
-    void processor_shouldReturnArticle_whenKeywordIsGiven() {
+    void processor_shouldReturnArticle_whenKeywordIsGiven() throws Exception {
         //given
         Keyword keyword = new Keyword("AI");
         List<Article> articles = List.of(
@@ -45,5 +46,6 @@ public class KeywordToArticlesProcessorTest {
 
         Assertions.assertThat(result.size()).isEqualTo(1);
         Assertions.assertThat(result.get(0).getTitle()).isEqualTo("AI");
+        BDDMockito.then(naverNewsClient).should(times(1)).fetchArticles(any());
     }
 }

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/article/batch/KeywordToArticlesProcessorTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/article/batch/KeywordToArticlesProcessorTest.java
@@ -1,0 +1,49 @@
+package com.codeit.team2.monew.module.domain.article.batch;
+
+import static org.mockito.ArgumentMatchers.any;
+
+import com.codeit.team2.monew.module.domain.article.entity.Article;
+import com.codeit.team2.monew.module.domain.article.external.NaverNewsClient;
+import com.codeit.team2.monew.module.domain.interest.entity.Keyword;
+import java.time.Instant;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class KeywordToArticlesProcessorTest {
+
+    @Mock
+    private NaverNewsClient naverNewsClient;
+
+    private KeywordToArticlesProcessor processor;
+
+    @BeforeEach
+    void setup() {
+        processor = new KeywordToArticlesProcessor(naverNewsClient);
+    }
+
+    @Test
+    void processor_shouldReturnArticle_whenKeywordIsGiven() {
+        //given
+        Keyword keyword = new Keyword("AI");
+        List<Article> articles = List.of(
+            new Article("AI", "NAVER", "https://test.com", "this is test summary", 0,
+                Instant.now(), false));
+
+        BDDMockito.given(naverNewsClient.fetchArticles(any()))
+            .willReturn(articles);
+
+        // when
+
+        List<Article> result = processor.process(keyword);
+
+        Assertions.assertThat(result.size()).isEqualTo(1);
+        Assertions.assertThat(result.get(0).getTitle()).isEqualTo("AI");
+    }
+}


### PR DESCRIPTION
## 구현 내용
- 기사 Batch 프로세스에 필요한 Writer, Processor 테스트 및 구현

## 테스트 완료 사항
<!-- 테스트한 항목에 체크(x)해주세요 -->
- [x] 단위 테스트
- [ ] 통합 테스트
- [ ] API 테스트 (Swagger/Postman 등)
- [ ] 기타 테스트


## 체크리스트
<!-- 제출 전 확인해야 할 사항들입니다 -->
- [x] 코딩, 커밋 컨벤션 준수
- [x] 모든 테스트 통과
- [ ] API 명세 준수
- [x] 불필요한 로그, 주석, 미사용 코드 제거

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #30 

## 추가 코멘트 (선택)
- Reader 는 Keyword 도메인 레포지토리 완성 후 구현 예정
- 프로세스 flow
    - reader 로 KeywordRepository 에서 keyword 들을 읽어옴
    - 읽어온 keyword 로 Processor에서 Naver News API 호출 
    - Writer 를 통해 Article 테이블에 삽입
