### PR TITLE
feat/#37/article-interest

### DIFF
--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/entity/Article.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/entity/Article.java
@@ -2,10 +2,16 @@ package com.codeit.team2.monew.module.domain.article.entity;
 
 
 import com.codeit.team2.monew.module.domain.BaseEntity;
+import com.codeit.team2.monew.module.domain.interest.entity.Interest;
+import com.codeit.team2.monew.module.domain.relation.entity.ArticleInterest;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -19,7 +25,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class Article extends BaseEntity {
 
-    //TODO : interest 필드 추가
     @Column(nullable = false)
     private String title;
 
@@ -31,6 +36,16 @@ public class Article extends BaseEntity {
 
     @Column(nullable = false)
     private String summary;
+
+    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<ArticleInterest> articleInterests = new HashSet<>();
+
+    //TODO
+    public void addInterest(Interest interest, Set<String> attachedKeywords) {
+        ArticleInterest articleInterest = new ArticleInterest();
+
+    }
+
 
     private Integer viewCount;
     private Instant publishedDate;

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/controller/InterestController.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/controller/InterestController.java
@@ -1,4 +1,4 @@
-package com.codeit.team2.monew.module.controller.interest;
+package com.codeit.team2.monew.module.domain.interest.controller;
 
 import com.codeit.team2.monew.module.domain.interest.dto.InterestDto;
 import com.codeit.team2.monew.module.service.InterestService;

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/controller/InterestRegisterRequest.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/controller/InterestRegisterRequest.java
@@ -1,4 +1,4 @@
-package com.codeit.team2.monew.module.controller.interest;
+package com.codeit.team2.monew.module.domain.interest.controller;
 
 import java.util.List;
 import lombok.Builder;

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/dto/InterestDto.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/dto/InterestDto.java
@@ -1,6 +1,5 @@
 package com.codeit.team2.monew.module.domain.interest.dto;
 
-import com.codeit.team2.monew.module.domain.interest.entity.Keyword;
 import java.util.List;
 import java.util.UUID;
 

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/entity/Interest.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/entity/Interest.java
@@ -1,13 +1,16 @@
 package com.codeit.team2.monew.module.domain.interest.entity;
 
 import com.codeit.team2.monew.module.domain.BaseEntity;
+import com.codeit.team2.monew.module.domain.relation.entity.ArticleInterest;
 import com.codeit.team2.monew.module.domain.subscription.entity.Subscription;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,7 +18,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 
 @Entity
-@Table(name="interests")
+@Table(name = "interests")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Interest extends BaseEntity {
@@ -33,8 +36,11 @@ public class Interest extends BaseEntity {
     @OneToMany(mappedBy = "interest", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Subscription> subscriptions;
 
+    @OneToMany(mappedBy = "interest", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<ArticleInterest> articleInterests = new HashSet<>();
+
     @Builder
-    public Interest (String name, int subscriberCount, List<InterestKeyword> keywords,
+    public Interest(String name, int subscriberCount, List<InterestKeyword> keywords,
         List<Subscription> subscriptions) {
         this.name = name;
         this.subscriberCount = subscriberCount;

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/entity/Keyword.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/entity/Keyword.java
@@ -5,7 +5,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/mapper/InterestMapper.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/mapper/InterestMapper.java
@@ -1,8 +1,7 @@
-package com.codeit.team2.monew.module.mapper.interest;
+package com.codeit.team2.monew.module.domain.interest.mapper;
 
 import com.codeit.team2.monew.module.domain.interest.dto.InterestDto;
 import com.codeit.team2.monew.module.domain.interest.entity.Interest;
-import com.codeit.team2.monew.module.domain.interest.entity.Keyword;
 import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/repository/InterestRepository.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/repository/InterestRepository.java
@@ -1,4 +1,4 @@
-package com.codeit.team2.monew.module.repository.interest;
+package com.codeit.team2.monew.module.domain.interest.repository;
 
 import com.codeit.team2.monew.module.domain.interest.entity.Interest;
 import java.util.UUID;

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/repository/KeywordRepository.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/repository/KeywordRepository.java
@@ -1,4 +1,4 @@
-package com.codeit.team2.monew.module.repository.interest;
+package com.codeit.team2.monew.module.domain.interest.repository;
 
 import com.codeit.team2.monew.module.domain.interest.entity.Keyword;
 import java.util.Optional;

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/relation/entity/ArticleInterest.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/relation/entity/ArticleInterest.java
@@ -1,0 +1,32 @@
+package com.codeit.team2.monew.module.domain.relation.entity;
+
+
+import com.codeit.team2.monew.module.domain.BaseEntity;
+import com.codeit.team2.monew.module.domain.article.entity.Article;
+import com.codeit.team2.monew.module.domain.interest.entity.Interest;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "article_interest")
+@Getter
+@NoArgsConstructor
+public class ArticleInterest extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "article_id", nullable = false)
+    private Article article;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "interest_id", nullable = false)
+    private Interest interest;
+
+}
+
+
+

--- a/monew/src/main/java/com/codeit/team2/monew/module/service/InterestService.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/service/InterestService.java
@@ -1,16 +1,15 @@
 package com.codeit.team2.monew.module.service;
 
-import com.codeit.team2.monew.module.controller.interest.InterestRegisterRequest;
+import com.codeit.team2.monew.module.domain.interest.controller.InterestRegisterRequest;
 import com.codeit.team2.monew.module.domain.interest.dto.InterestDto;
 import com.codeit.team2.monew.module.domain.interest.entity.Interest;
 import com.codeit.team2.monew.module.domain.interest.entity.Keyword;
-import com.codeit.team2.monew.module.mapper.interest.InterestMapper;
-import com.codeit.team2.monew.module.repository.interest.InterestRepository;
-import com.codeit.team2.monew.module.repository.interest.KeywordRepository;
+import com.codeit.team2.monew.module.domain.interest.mapper.InterestMapper;
+import com.codeit.team2.monew.module.domain.interest.repository.InterestRepository;
+import com.codeit.team2.monew.module.domain.interest.repository.KeywordRepository;
 import jakarta.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -27,7 +26,6 @@ public class InterestService {
     public InterestDto create(InterestRegisterRequest request) {
 
         // 관심사 이름 유사도 검사: 80% 이상 일치 시 등록 불가
-
 
         List<Keyword> newKeywords = new ArrayList<>();
 
@@ -46,7 +44,7 @@ public class InterestService {
             .subscriberCount(0)
             .build();
 
-        return InterestMapper.INSTANCE.toDto(interest, List.of(request.keywords().get(0)) ,true);
+        return InterestMapper.INSTANCE.toDto(interest, List.of(request.keywords().get(0)), true);
     }
 
 }

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/interest/service/InterestServiceTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/interest/service/InterestServiceTest.java
@@ -1,10 +1,11 @@
-package com.codeit.team2.monew.module.service;
+package com.codeit.team2.monew.module.domain.interest.service;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.codeit.team2.monew.module.controller.interest.InterestRegisterRequest;
+import com.codeit.team2.monew.module.domain.interest.controller.InterestRegisterRequest;
 import com.codeit.team2.monew.module.domain.interest.dto.InterestDto;
-import com.codeit.team2.monew.module.repository.interest.InterestRepository;
+import com.codeit.team2.monew.module.domain.interest.repository.InterestRepository;
+import com.codeit.team2.monew.module.service.InterestService;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,7 +30,7 @@ class InterestServiceTest {
     void create() {
         // given
         List<String> keywords = List.of("이거");
-        InterestRegisterRequest request =  new InterestRegisterRequest("이름", keywords);
+        InterestRegisterRequest request = new InterestRegisterRequest("이름", keywords);
 
         // when
         InterestDto interestDto = interestService.create(request);


### PR DESCRIPTION
## 구현 내용
<!-- 구현한 기능에 대한 간략한 설명을 작성해주세요 -->
뉴스 기사 관리와 관심사 관리 엔티티 사이의 다대다 관계를 중간 엔티티를 통해 1:N 관계로 풀어내기 위해 ArticleInterest 엔티티 추가 및 연관관계 설정
### 구현된 API 엔드포인트
<!-- 구현한 API 엔드포인트 목록을 작성해주세요 -->
<!-- 예시:
- GET /api/employees - 직원 목록 조회
- POST /api/employees - 직원 등록
- GET /api/employees/{id} - 직원 상세 조회
- PATCH /api/employees/{id} - 직원 정보 수정
- DELETE /api/employees/{id} - 직원 삭제
- GET /api/employees/stats/trend - 직원 수 추이 조회
- GET /api/employees/stats/distribution - 직원 분포 조회
- GET /api/employees/count - 직원 수 조회 -->


### 주요 변경사항
<!-- 주요 변경사항을 작성해주세요 -->
- 
- 
- 

## 테스트 완료 사항
<!-- 테스트한 항목에 체크(x)해주세요 -->
- [ ] 단위 테스트
- [ ] 통합 테스트
- [ ] API 테스트 (Swagger/Postman 등)
- [ ] 기타 테스트

## 스크린샷
<!-- 필요한 경우 관련 스크린샷을 첨부해주세요 -->

## 체크리스트
<!-- 제출 전 확인해야 할 사항들입니다 -->
- [ ] 코딩, 커밋 컨벤션 준수
- [ ] 모든 테스트 통과
- [ ] API 명세 준수
- [ ] 불필요한 로그, 주석, 미사용 코드 제거

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #37

## 추가 코멘트 (선택)
<!-- 리뷰어에게 전달할 추가 정보가 있다면 작성해주세요 -->
기본적인 엔티티만 추가하였기 떄문에 수정이 필요할 수 있습니다.
