### PR TITLE
[Feat]: 댓글 좋아요 관리 컨트롤러 구현 물리 삭제 api 추가

### DIFF
--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/controller/CommentController.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/controller/CommentController.java
@@ -80,4 +80,18 @@ public class CommentController {
 
         return ResponseEntity.noContent().build();
     }
+
+    @DeleteMapping("/{commentId}/hard")
+    public ResponseEntity<Void> hardDelete(
+        @PathVariable UUID commentId
+    ) {
+        log.info("Start - CommentController/hardDelete: commentId={}", commentId);
+
+        commentService.hardDelete(commentId);
+
+        log.info("Complete - CommentController/hardDelete: commentId={}", commentId);
+
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/controller/CommentLikeController.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/controller/CommentLikeController.java
@@ -1,0 +1,56 @@
+package com.codeit.team2.monew.module.domain.comment.controller;
+
+import com.codeit.team2.monew.module.domain.comment.dto.CommentLikeDto;
+import com.codeit.team2.monew.module.domain.comment.entity.CommentLike;
+import com.codeit.team2.monew.module.domain.comment.mapper.CommentMapper;
+import com.codeit.team2.monew.module.domain.comment.service.CommentLikeService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/comments/{commentId}/comment-likes")
+public class CommentLikeController {
+
+    private final CommentLikeService commentLikeService;
+    private final CommentMapper commentMapper;
+
+    @PostMapping
+    public ResponseEntity<CommentLikeDto> like(
+        @PathVariable UUID commentId,
+        @RequestHeader("Monew-Request-User-ID") UUID userId
+    ) {
+        log.info("Start - CommentLikeController/like: commentId={}, userId={}",
+            commentId, userId);
+
+        CommentLike commentLike = commentLikeService.like(commentId, userId);
+        CommentLikeDto result = commentMapper.toDto(commentLike);
+
+        log.info("Complete - CommentController/like: ");
+
+        return ResponseEntity.ok(result);
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> unlike(
+        @PathVariable UUID commentId,
+        @RequestHeader("Monew-Request-User-ID") UUID userId
+    ) {
+        log.info("Start - CommentLikeController/unlike: commentId={}, userId={}",
+            commentId, userId);
+
+        commentLikeService.unlike(commentId, userId);
+
+        log.info("Complete - CommentController/unlike");
+        return ResponseEntity.ok().build();
+    }
+}

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/controller/CommentLikeController.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/controller/CommentLikeController.java
@@ -35,7 +35,7 @@ public class CommentLikeController {
         CommentLike commentLike = commentLikeService.like(commentId, userId);
         CommentLikeDto result = commentMapper.toDto(commentLike);
 
-        log.info("Complete - CommentController/like: ");
+        log.info("Complete - CommentLikeController/like: commentLikeId={}", result.id());
 
         return ResponseEntity.ok(result);
     }
@@ -50,7 +50,8 @@ public class CommentLikeController {
 
         commentLikeService.unlike(commentId, userId);
 
-        log.info("Complete - CommentController/unlike");
+        log.info("Complete - CommentLikeController/unlike: commentId={}, userId={}", commentId,
+            userId);
         return ResponseEntity.ok().build();
     }
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/service/CommentService.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/service/CommentService.java
@@ -15,6 +15,8 @@ public interface CommentService {
 
     void delete(UUID commentId, UUID userId);
 
+    void hardDelete(UUID commentId);
+
 //    public List<CommentDto> getCommentsByArticleId(UUID articleId, UUID userId, UUID cursor,
 //        Instant cursorTime, int limit);
 //

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/service/CommentServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/service/CommentServiceImpl.java
@@ -80,4 +80,15 @@ public class CommentServiceImpl implements CommentService {
 
         comment.delete();
     }
+
+    @Override
+    public void hardDelete(UUID commentId) {
+        Comment comment = commentRepository.findById(commentId)
+            .orElseThrow(() -> {
+                log.debug("Comment Not Found - commentId: {}", commentId);
+                return new EntityNotFoundException("Comment Not Found");
+            });
+
+        commentRepository.delete(comment);
+    }
 }


### PR DESCRIPTION
## 구현 내용
<!-- 구현한 기능에 대한 간략한 설명을 작성해주세요 -->
CommentLikeController 구현(like, unlike) 및 댓글 물리 삭제 api 추가

### 구현된 API 엔드포인트
<!-- 구현한 API 엔드포인트 목록을 작성해주세요 -->
<!-- 예시:
- GET /api/employees - 직원 목록 조회
- POST /api/employees - 직원 등록
- GET /api/employees/{id} - 직원 상세 조회
- PATCH /api/employees/{id} - 직원 정보 수정
- DELETE /api/employees/{id} - 직원 삭제
- GET /api/employees/stats/trend - 직원 수 추이 조회
- GET /api/employees/stats/distribution - 직원 분포 조회
- GET /api/employees/count - 직원 수 조회 -->
- [HTTP 메서드] [경로] - [설명]


### 주요 변경사항
<!-- 주요 변경사항을 작성해주세요 -->
- [POST, DELETE] /api/comments/{commentId}/comment-likes
- [DELETE] /api/comments/{commentId}/hard

## 테스트 완료 사항
<!-- 테스트한 항목에 체크(x)해주세요 -->
- [ ] 단위 테스트
- [ ] 통합 테스트
- [ ] API 테스트 (Swagger/Postman 등)
- [ ] 기타 테스트

## 스크린샷
<!-- 필요한 경우 관련 스크린샷을 첨부해주세요 -->

## 체크리스트
<!-- 제출 전 확인해야 할 사항들입니다 -->
- [x] 코딩, 커밋 컨벤션 준수
- [ ] 모든 테스트 통과
- [x] API 명세 준수
- [x] 불필요한 로그, 주석, 미사용 코드 제거

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #60 

## 추가 코멘트 (선택)
<!-- 리뷰어에게 전달할 추가 정보가 있다면 작성해주세요 -->
Admin인 경우에만 물리 삭제를 할 수 있게 하는 Admin 역할을 추가해보는건 어떨지 생각이 들었습니다