### PR TITLE
feat: 알림 삭제 배치 기능 #55

### DIFF
--- a/monew/src/main/java/com/codeit/team2/monew/MonewApplication.java
+++ b/monew/src/main/java/com/codeit/team2/monew/MonewApplication.java
@@ -2,8 +2,10 @@ package com.codeit.team2.monew;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class MonewApplication {
 
     public static void main(String[] args) {

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/batch/NotificationBatchConfig.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/batch/NotificationBatchConfig.java
@@ -22,7 +22,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 public class NotificationBatchConfig {
 
     @Bean
-    public Job deleteNotificationsJob(JobRepository jobRepository,
+    public Job deleteNotificationJob(JobRepository jobRepository,
         Step deleteNotificationStep) {
         return new JobBuilder("deleteNotificationJob", jobRepository)
             .start(deleteNotificationStep)

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/batch/NotificationBatchConfig.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/batch/NotificationBatchConfig.java
@@ -1,0 +1,55 @@
+package com.codeit.team2.monew.module.domain.notification.batch;
+
+import com.codeit.team2.monew.module.domain.notification.repository.NotificationRepository;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@Slf4j
+@RequiredArgsConstructor
+public class NotificationBatchConfig {
+
+    @Bean
+    public Job deleteNotificationsJob(JobRepository jobRepository,
+        Step deleteNotificationStep) {
+        return new JobBuilder("deleteNotificationJob", jobRepository)
+            .start(deleteNotificationStep)
+            .build();
+    }
+
+    @Bean
+    public Step deleteNotificationStep(JobRepository jobRepository,
+        PlatformTransactionManager transactionManager,
+        Tasklet deleteNotificationTasklet) {
+        return new StepBuilder("deleteNotificationStep", jobRepository)
+            .tasklet(deleteNotificationTasklet, transactionManager)
+            .build();
+    }
+
+    @Bean
+    public Tasklet deleteNotificationTasklet(NotificationRepository notificationRepository) {
+        return (contribution, chunkContext) -> {
+            Instant oneWeekAgo = Instant.now().minus(7, ChronoUnit.DAYS);
+            int deletedCount = notificationRepository.deleteByConfirmedIsTrueAndCreatedAtBefore(
+                oneWeekAgo);
+            log.info("Batch Completed: Confirmed and old notifications deleted: count = {}",
+                deletedCount);
+            return RepeatStatus.FINISHED;
+        };
+    }
+
+}
+
+

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/batch/NotificationScheduler.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/batch/NotificationScheduler.java
@@ -1,21 +1,28 @@
 package com.codeit.team2.monew.module.domain.notification.batch;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
-@RequiredArgsConstructor
 @Slf4j
 public class NotificationScheduler {
 
     private final JobLauncher jobLauncher;
     private final Job deleteNotificationJob;
+
+    public NotificationScheduler(
+        JobLauncher jobLauncher,
+        @Qualifier("deleteNotificationJob") Job deleteNotificationJob
+    ) {
+        this.jobLauncher = jobLauncher;
+        this.deleteNotificationJob = deleteNotificationJob;
+    }
 
     @Scheduled(cron = "0 0 3 * * *")    // 매일 오전 3시
     public void runJob() throws Exception {

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/batch/NotificationScheduler.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/batch/NotificationScheduler.java
@@ -1,0 +1,28 @@
+package com.codeit.team2.monew.module.domain.notification.batch;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job deleteNotificationJob;
+
+    @Scheduled(cron = "0 0 3 * * *")    // 매일 오전 3시
+    public void runJob() throws Exception {
+        JobParameters parameters = new JobParametersBuilder()
+            .addLong("timestamp", System.currentTimeMillis())
+            .toJobParameters();
+        log.info("Batch Processing Start: Delete confirmed and old notifications");
+        jobLauncher.run(deleteNotificationJob, parameters);
+    }
+}

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/repository/NotificationRepository.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/repository/NotificationRepository.java
@@ -1,6 +1,8 @@
 package com.codeit.team2.monew.module.domain.notification.repository;
 
 import com.codeit.team2.monew.module.domain.notification.entity.Notification;
+import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -13,4 +15,10 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
     @Query("UPDATE Notification n SET n.confirmed = true WHERE n.user.id = :userId AND n.confirmed = false")
     int confirmAllByUserId(@Param("userId") UUID userId);
 
+    @Query("select n from Notification n where n.confirmed=true AND n.createdAt<:time")
+    List<Notification> findAllToBeDeleted(Instant time);
+
+    @Modifying
+    @Query("delete from Notification n where n.confirmed = true and n.createdAt < :time")
+    int deleteByConfirmedIsTrueAndCreatedAtBefore(@Param("time") Instant time);
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/repository/NotificationRepository.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/repository/NotificationRepository.java
@@ -2,7 +2,6 @@ package com.codeit.team2.monew.module.domain.notification.repository;
 
 import com.codeit.team2.monew.module.domain.notification.entity.Notification;
 import java.time.Instant;
-import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -14,9 +13,6 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
     @Modifying
     @Query("UPDATE Notification n SET n.confirmed = true WHERE n.user.id = :userId AND n.confirmed = false")
     int confirmAllByUserId(@Param("userId") UUID userId);
-
-    @Query("select n from Notification n where n.confirmed=true AND n.createdAt<:time")
-    List<Notification> findAllToBeDeleted(Instant time);
 
     @Modifying
     @Query("delete from Notification n where n.confirmed = true and n.createdAt < :time")

--- a/monew/src/main/resources/application.yaml
+++ b/monew/src/main/resources/application.yaml
@@ -24,6 +24,7 @@ spring:
     jdbc:
       initialize-schema: always  # 개발 환경에서는 'always', 운영 환경에서는 'never'
     job:
+      name: deleteNotificationJob
       enabled: false  # 애플리케이션 시작 시 모든 배치 작업 자동 실행 방지
 
 logging:
@@ -37,3 +38,4 @@ news:
     url: https://openapi.naver.com
     client-id: ${NAVER_CLIENT_ID}
     client-secret: ${NAVER_CLIENT_SECRET}
+


### PR DESCRIPTION
## 구현 내용
<!-- 구현한 기능에 대한 간략한 설명을 작성해주세요 -->
- 확인한 알림 중 1주일이 경과된 알림은 자동으로 삭제됩니다.
- 삭제는 매일 배치로 수행합니다.

### 구현된 API 엔드포인트
미해당

### 주요 변경사항
<!-- 주요 변경사항을 작성해주세요 -->
- Batch Configuration으로 오래된 알림 삭제 작업을 자동으로 실행되게 하였습니다.
- 이 배치 작업은 매일 오전 3시에 실행되도록 스케줄링했습니다.

## 테스트 완료 사항
<!-- 테스트한 항목에 체크(x)해주세요 -->
- [ ] 단위 테스트
- [ ] 통합 테스트
- [ ] API 테스트 (Swagger/Postman 등)
- [ ] 기타 테스트

## 스크린샷
<!-- 필요한 경우 관련 스크린샷을 첨부해주세요 -->

## 체크리스트
<!-- 제출 전 확인해야 할 사항들입니다 -->
- [x] 코딩, 커밋 컨벤션 준수
- [ ] 모든 테스트 통과
- [ ] API 명세 준수
- [x] 불필요한 로그, 주석, 미사용 코드 제거

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #55

## 추가 코멘트 (선택)
<!-- 리뷰어에게 전달할 추가 정보가 있다면 작성해주세요 -->

배치 작업은 코드에서 호출하는 게 아니고, 스케줄링으로 자동 실행되는 거라
테스트 코드를 어떻게 작성해야 할지 모르겠습니다.

그래서 임의로 30초마다 작업이 수행되도록 스케줄링하여 아래 두 가지 조건을 확인하는 것으로 테스트를 대신했습니다.
1. 배치 작업이 정상적으로 실행되는가
2. DB에서 적절한 데이터를 처리하는가

