### PR TITLE
feat/#68/notification read

### DIFF
--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/controller/NotificationController.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/controller/NotificationController.java
@@ -27,15 +27,20 @@ public class NotificationController {
     public ResponseEntity<Void> confirmNotification(
         @RequestHeader("Monew-Request-User-ID") UUID userId,
         @PathVariable UUID notificationId) {
-
-        notificationService.readNotification(userId, notificationId);
+        log.info("Start - NotificationController/confirmNotification: notificationId = {}",
+            notificationId);
+        notificationService.confirmNotification(userId, notificationId);
+        log.info("Complete - NotificationController/confirmNotification: notificationId = {}",
+            notificationId);
         return ResponseEntity.ok().build();
     }
 
     @PatchMapping("")
     public ResponseEntity<Void> confirmAllNotifications(
         @RequestHeader("Monew-Request-User-ID") UUID userId) {
-        notificationService.readAllNotifications(userId);
+        log.info("Start - NotificationController/confirmAllNotifications: userId = {}", userId);
+        notificationService.confirmAllNotifications(userId);
+        log.info("Complete - NotificationController/confirmAllNotifications: userId = {}", userId);
         return ResponseEntity.ok().build();
     }
 
@@ -45,6 +50,10 @@ public class NotificationController {
         @RequestParam(required = false) Instant cursor,
         @RequestParam(required = false) Instant after,
         @RequestParam(required = true) int limit) {
-        return ResponseEntity.ok(notificationService.findAll(userId, cursor, after, limit));
+        log.info("Start - NotificationController/findAll: userId = {}", userId);
+        CursorPageResponseNotificationDto result = notificationService.findAll(userId, cursor,
+            after, limit);
+        log.info("Complete - NotificationController/findAll: userId = {}", userId);
+        return ResponseEntity.ok(result);
     }
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/controller/NotificationController.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/controller/NotificationController.java
@@ -1,17 +1,23 @@
 package com.codeit.team2.monew.module.domain.notification.controller;
 
+import com.codeit.team2.monew.module.domain.notification.dto.CursorPageResponseNotificationDto;
 import com.codeit.team2.monew.module.domain.notification.service.NotificationService;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 @RequestMapping("/api/notifications")
 public class NotificationController {
 
@@ -21,6 +27,7 @@ public class NotificationController {
     public ResponseEntity<Void> confirmNotification(
         @RequestHeader("Monew-Request-User-ID") UUID userId,
         @PathVariable UUID notificationId) {
+
         notificationService.readNotification(userId, notificationId);
         return ResponseEntity.ok().build();
     }
@@ -30,5 +37,14 @@ public class NotificationController {
         @RequestHeader("Monew-Request-User-ID") UUID userId) {
         notificationService.readAllNotifications(userId);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("")
+    public ResponseEntity<CursorPageResponseNotificationDto> findAll(
+        @RequestHeader("Monew-Request-User-ID") UUID userId,
+        @RequestParam(required = false) Instant cursor,
+        @RequestParam(required = false) Instant after,
+        @RequestParam(required = true) int limit) {
+        return ResponseEntity.ok(notificationService.findAll(userId, cursor, after, limit));
     }
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/dto/CursorPageResponseNotificationDto.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/dto/CursorPageResponseNotificationDto.java
@@ -8,8 +8,8 @@ public record CursorPageResponseNotificationDto(
     Object nextCursor,
     Instant nextAfter,
     int size,
-    Long totalElements,
-    boolean hasNexts
+    long totalElements,
+    boolean hasNext
 ) {
 
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/mapper/NotificationMapper.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/mapper/NotificationMapper.java
@@ -1,0 +1,13 @@
+package com.codeit.team2.monew.module.domain.notification.mapper;
+
+import com.codeit.team2.monew.module.domain.notification.dto.NotificationDto;
+import com.codeit.team2.monew.module.domain.notification.entity.Notification;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface NotificationMapper {
+
+    @Mapping(source = "user.id", target = "userId")
+    NotificationDto toDto(Notification notification);
+}

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/repository/NotificationRepository.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/repository/NotificationRepository.java
@@ -3,6 +3,8 @@ package com.codeit.team2.monew.module.domain.notification.repository;
 import com.codeit.team2.monew.module.domain.notification.entity.Notification;
 import java.time.Instant;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -15,6 +17,24 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
     int confirmAllByUserId(@Param("userId") UUID userId);
 
     @Modifying
-    @Query("delete from Notification n where n.confirmed = true and n.createdAt < :time")
+    @Query("DELETE FROM Notification n WHERE n.confirmed = true AND n.createdAt < :time")
     int deleteByConfirmedIsTrueAndCreatedAtBefore(@Param("time") Instant time);
+
+    @Query("SELECT n FROM Notification n "
+        + "WHERE n.user.id = :userId "
+        + "AND n.confirmed = false "
+        + "AND n.createdAt > :cursor "
+        + "ORDER BY n.createdAt ASC, n.id DESC ")
+    Page<Notification> findPageWithCursor(@Param("userId") UUID userId,
+        @Param("cursor") Instant cursor, Pageable pageable);
+
+    @Query("SELECT n FROM Notification n "
+        + "WHERE n.user.id = :userId "
+        + "AND n.confirmed = false "
+        + "ORDER BY n.createdAt ASC, n.id DESC ")
+    Page<Notification> findFirstPage(@Param("userId") UUID userId, Pageable pageable);
+
+    @Query("SELECT COUNT(n) FROM Notification  n WHERE n.user.id"
+        + "=:userId AND n.confirmed = false ")
+    long countForPagination(@Param("userId") UUID userId);
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/service/NotificationService.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/service/NotificationService.java
@@ -18,10 +18,10 @@ public interface NotificationService {
     List<Notification> createInterestNotification(List<Article> articles);
 
     // 개별 알림 확인
-    void readNotification(UUID userID, UUID notificationId);
+    void confirmNotification(UUID userID, UUID notificationId);
 
     // 전체 알림 확인
-    void readAllNotifications(UUID userId);
+    void confirmAllNotifications(UUID userId);
 
     // 알림 목록 조회 - 커서페이지네이션
     CursorPageResponseNotificationDto findAll(UUID userId, Instant cursor, Instant after,

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/service/NotificationService.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/service/NotificationService.java
@@ -2,8 +2,10 @@ package com.codeit.team2.monew.module.domain.notification.service;
 
 import com.codeit.team2.monew.module.domain.article.entity.Article;
 import com.codeit.team2.monew.module.domain.comment.entity.Comment;
+import com.codeit.team2.monew.module.domain.notification.dto.CursorPageResponseNotificationDto;
 import com.codeit.team2.monew.module.domain.notification.entity.Notification;
 import com.codeit.team2.monew.module.domain.user.entity.User;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -20,4 +22,8 @@ public interface NotificationService {
 
     // 전체 알림 확인
     void readAllNotifications(UUID userId);
+
+    // 알림 목록 조회 - 커서페이지네이션
+    CursorPageResponseNotificationDto findAll(UUID userId, Instant cursor, Instant after,
+        int limit);
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImpl.java
@@ -137,6 +137,10 @@ public class NotificationServiceImpl implements NotificationService {
     @Override
     public CursorPageResponseNotificationDto findAll(UUID userId, Instant cursor, Instant after,
         int limit) {
+        if (!userRepository.existsById(userId)) {
+            log.debug("[Notification finding] Failed: User not found - userId: {}", userId);
+            throw new RuntimeException("User Not Found");
+        }
         // 정렬 조건은 시간 순으로 고정
         Pageable pageable = PageRequest.of(0, limit, Sort.by(Direction.ASC, "createdAt"));
         Page<Notification> pages;

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImpl.java
@@ -2,6 +2,7 @@ package com.codeit.team2.monew.module.domain.notification.service;
 
 import com.codeit.team2.monew.module.domain.article.entity.Article;
 import com.codeit.team2.monew.module.domain.comment.entity.Comment;
+import com.codeit.team2.monew.module.domain.comment.repository.CommentRepository;
 import com.codeit.team2.monew.module.domain.interest.entity.Interest;
 import com.codeit.team2.monew.module.domain.notification.dto.CursorPageResponseNotificationDto;
 import com.codeit.team2.monew.module.domain.notification.dto.NotificationDto;
@@ -21,6 +22,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -30,21 +32,32 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class NotificationServiceImpl implements NotificationService {
 
     private final NotificationRepository notificationRepository;
     private final UserRepository userRepository;
+    private final CommentRepository commentRepository;
     private final SubscriptionRepository subscriptionRepository;
     private final NotificationMapper notificationMapper;
 
     @Transactional
     @Override
     public Notification createCommentNotification(Comment comment, User author, User liker) {
-        // Comment 검증 로직 추가 예정
-        if (!userRepository.existsById(author.getId()) || !userRepository.existsById(
-            liker.getId())) {
-            throw new RuntimeException("User or Comment Not Found");
+        if (!commentRepository.existsById(comment.getId())) {
+            log.debug("[Notification Creation] Failed: Comment not found - commentId: {}",
+                comment.getId());
+            throw new RuntimeException("Comment not found");
+        }
+        if (!userRepository.existsById(author.getId())) {
+            log.debug("[Notification Creation] Failed: Author not found - authorId: {}",
+                author.getId());
+            throw new RuntimeException("Author not found");
+        } else if (!userRepository.existsById(liker.getId())) {
+            log.debug("[Notification Creation] Failed: Liker not found - likerId: {}",
+                liker.getId());
+            throw new RuntimeException("Liker not found");
         }
         String content = liker.getNickname() + "님이 나의 댓글을 좋아합니다.";
         Notification notification = new Notification(author, content, comment.getId(),
@@ -86,16 +99,25 @@ public class NotificationServiceImpl implements NotificationService {
 
     @Transactional
     @Override
-    public void readNotification(UUID userId, UUID notificationId) {
+    public void confirmNotification(UUID userId, UUID notificationId) {
         // 사용자 정보 확인
         if (!userRepository.existsById(userId)) {
+            log.debug("[Notification Confirm] Failed: User not found - userId: {}", userId);
             throw new RuntimeException("User Not Found");
         }
         Notification notification = notificationRepository.findById(notificationId)
-            .orElseThrow(() -> new RuntimeException("Notification Not Found"));
+            .orElseThrow(() -> {
+                log.debug(
+                    "[Notification Confirm] Failed: Notification not found - notificationId: {}",
+                    notificationId);
+                return new RuntimeException("Notification Not Found");
+            });
 
         if (!notification.getUser().getId().equals(userId)) {
-            throw new RuntimeException("This user cannot access to this notification");
+            log.debug(
+                "[Notification Confirm] Failed: User Access Denied - userId: {}, notificationId = {}",
+                userId, notificationId);
+            throw new RuntimeException("User Access Denied");
         }
 
         notification.confirm();
@@ -103,9 +125,10 @@ public class NotificationServiceImpl implements NotificationService {
 
     @Transactional
     @Override
-    public void readAllNotifications(UUID userId) {
+    public void confirmAllNotifications(UUID userId) {
         // 사용자 정보 확인
         if (!userRepository.existsById(userId)) {
+            log.debug("[Notification Confirm] Failed: User not found - userId: {}", userId);
             throw new RuntimeException("User Not Found");
         }
         notificationRepository.confirmAllByUserId(userId);

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImpl.java
@@ -51,11 +51,11 @@ public class NotificationServiceImpl implements NotificationService {
             throw new RuntimeException("Comment not found");
         }
         if (!userRepository.existsById(author.getId())) {
-            log.debug("[Notification Creation] Failed: Author not found - authorId: {}",
+            log.debug("[Notification Creation] Failed: Author not found - userId: {}",
                 author.getId());
             throw new RuntimeException("Author not found");
         } else if (!userRepository.existsById(liker.getId())) {
-            log.debug("[Notification Creation] Failed: Liker not found - likerId: {}",
+            log.debug("[Notification Creation] Failed: Liker not found - userId: {}",
                 liker.getId());
             throw new RuntimeException("Liker not found");
         }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImpl.java
@@ -3,19 +3,29 @@ package com.codeit.team2.monew.module.domain.notification.service;
 import com.codeit.team2.monew.module.domain.article.entity.Article;
 import com.codeit.team2.monew.module.domain.comment.entity.Comment;
 import com.codeit.team2.monew.module.domain.interest.entity.Interest;
+import com.codeit.team2.monew.module.domain.notification.dto.CursorPageResponseNotificationDto;
+import com.codeit.team2.monew.module.domain.notification.dto.NotificationDto;
 import com.codeit.team2.monew.module.domain.notification.entity.Notification;
 import com.codeit.team2.monew.module.domain.notification.entity.ResourceType;
+import com.codeit.team2.monew.module.domain.notification.mapper.NotificationMapper;
 import com.codeit.team2.monew.module.domain.notification.repository.NotificationRepository;
 import com.codeit.team2.monew.module.domain.subscription.entity.Subscription;
 import com.codeit.team2.monew.module.domain.subscription.repository.SubscriptionRepository;
 import com.codeit.team2.monew.module.domain.user.entity.User;
 import com.codeit.team2.monew.module.domain.user.repository.UserRepository;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +36,7 @@ public class NotificationServiceImpl implements NotificationService {
     private final NotificationRepository notificationRepository;
     private final UserRepository userRepository;
     private final SubscriptionRepository subscriptionRepository;
+    private final NotificationMapper notificationMapper;
 
     @Transactional
     @Override
@@ -98,5 +109,36 @@ public class NotificationServiceImpl implements NotificationService {
             throw new RuntimeException("User Not Found");
         }
         notificationRepository.confirmAllByUserId(userId);
+    }
+
+    @Override
+    public CursorPageResponseNotificationDto findAll(UUID userId, Instant cursor, Instant after,
+        int limit) {
+        // 정렬 조건은 시간 순으로 고정
+        Pageable pageable = PageRequest.of(0, limit, Sort.by(Direction.ASC, "createdAt"));
+        Page<Notification> pages;
+        if (cursor != null) {
+            pages = notificationRepository.findPageWithCursor(userId, cursor, pageable);
+        } else {
+            pages = notificationRepository.findFirstPage(userId, pageable);
+        }
+        // dto로 변환
+        List<Notification> notifications = pages.getContent();
+        List<NotificationDto> notificationDtos = notifications.stream()
+            .map(notification -> notificationMapper.toDto(notification))
+            .collect(Collectors.toList());
+
+        int size = pages.getSize();
+        boolean hasNext = pages.hasNext();
+        Instant nextCursor = null;
+        Instant nextAfter = null;
+        if (hasNext) {
+            nextCursor = notificationDtos.get(notificationDtos.size() - 1).createdAt();
+            nextAfter = nextCursor;
+        }
+        long totalElements = notificationRepository.countForPagination(userId);
+
+        return new CursorPageResponseNotificationDto(notificationDtos, nextCursor, nextAfter, size,
+            totalElements, hasNext);
     }
 }

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/notification/controller/NotificationControllerTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/notification/controller/NotificationControllerTest.java
@@ -1,0 +1,83 @@
+package com.codeit.team2.monew.module.domain.notification.controller;
+
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.codeit.team2.monew.module.domain.notification.service.NotificationService;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ActiveProfiles("test")
+@WebMvcTest(NotificationController.class)
+class NotificationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private NotificationService notificationService;
+
+    @Test
+    @DisplayName("알림 확인 - 성공")
+    void confirmNotification() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID notificationId = UUID.randomUUID();
+
+        // when
+        mockMvc.perform(
+                patch("/api/notifications/{notificationId}", notificationId)
+                    .header("Monew-Request-User-ID", userId.toString())
+            )
+            .andExpect(status().isOk());
+
+        // then
+        verify(notificationService).confirmNotification(userId, notificationId);
+
+    }
+
+    @Test
+    @DisplayName("알림 전체 확인 - 성공")
+    void confirmAllNotifications() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+
+        // when
+        mockMvc.perform(
+                patch("/api/notifications")
+                    .header("Monew-Request-User-ID", userId.toString())
+            )
+            .andExpect(status().isOk());
+
+        // then
+        verify(notificationService).confirmAllNotifications(userId);
+
+    }
+
+    @Test
+    @DisplayName("알림 목록 조회 - 성공")
+    void findAll() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+
+        // when
+        mockMvc.perform(get("/api/notifications")
+                .header("Monew-Request-User-ID", userId.toString())
+                .param("limit", String.valueOf(50)))
+            .andExpect(status().isOk());
+
+        // then
+        verify(notificationService).findAll(userId, null, null, 50);
+
+    }
+
+
+}

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImplTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImplTest.java
@@ -95,6 +95,43 @@ class NotificationServiceImplTest {
         assertEquals(ResourceType.COMMENT, notification.getResourceType());
     }
 
+    @DisplayName("내 댓글에 좋아요 눌리면 알림 생성 - 실패: 댓글 검증 실패")
+    @Test
+    void createCommentNotificationShouldFail1() {
+        // given
+        UUID commentId = UUID.randomUUID();
+        Comment comment = mock(Comment.class);
+        User author = mock(User.class);
+        User liker = mock(User.class);
+
+        when(comment.getId()).thenReturn(commentId);
+        when(commentRepository.existsById(commentId)).thenReturn(false);
+
+        // when & then
+        assertThrows(RuntimeException.class,
+            () -> notificationService.createCommentNotification(comment, author, liker));
+    }
+
+    @DisplayName("내 댓글에 좋아요 눌리면 알림 생성 - 실패: 유저 검증 실패")
+    @Test
+    void createCommentNotificationShouldFail2() {
+        // given
+        UUID commentId = UUID.randomUUID();
+        Comment comment = mock(Comment.class);
+        UUID authorId = UUID.randomUUID();
+        User author = mock(User.class);
+        User liker = mock(User.class);
+
+        when(comment.getId()).thenReturn(commentId);
+        when(commentRepository.existsById(commentId)).thenReturn(true);
+        when(author.getId()).thenReturn(authorId);
+        when(userRepository.existsById(authorId)).thenReturn(false);
+
+        // when & then
+        assertThrows(RuntimeException.class,
+            () -> notificationService.createCommentNotification(comment, author, liker));
+    }
+
     @DisplayName("구독한 관심사 관련 기사가 등록되면 알림 생성 - 성공")
     @Test
     void createInterestNotification() {
@@ -155,9 +192,34 @@ class NotificationServiceImplTest {
         assertEquals(true, notification.isConfirmed());
     }
 
-    @DisplayName("알림 확인 - 실패")
+    @DisplayName("알림 확인 - 실패: 유저 검증 실패")
     @Test
-    void confirmNotificationShouldFail() {
+    void confirmNotificationShouldFail1() {
+        // given
+        UUID notificationId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        when(userRepository.existsById(userId)).thenReturn(false);
+        // when & then
+        assertThrows(RuntimeException.class,
+            () -> notificationService.confirmNotification(userId, notificationId));
+    }
+
+    @DisplayName("알림 확인 - 실패: 알림 검증 실패")
+    @Test
+    void confirmNotificationShouldFail2() {
+        // given
+        UUID notificationId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        when(userRepository.existsById(userId)).thenReturn(true);
+        when(notificationRepository.findById(notificationId)).thenReturn(Optional.empty());
+        // when & then
+        assertThrows(RuntimeException.class,
+            () -> notificationService.confirmNotification(userId, notificationId));
+    }
+
+    @DisplayName("알림 확인 - 실패: 알림의 소유자가 아님")
+    @Test
+    void confirmNotificationShouldFail3() {
         // given
         UUID notificationId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImplTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImplTest.java
@@ -133,7 +133,7 @@ class NotificationServiceImplTest {
         when(notification.getUser().getId()).thenReturn(userId);
 
         // when
-        notificationService.readNotification(userId, notificationId);
+        notificationService.confirmNotification(userId, notificationId);
 
         // then
         assertEquals(true, notification.isConfirmed());
@@ -154,7 +154,7 @@ class NotificationServiceImplTest {
 
         // when & then
         assertThrows(RuntimeException.class,
-            () -> notificationService.readNotification(userId, notificationId));
+            () -> notificationService.confirmNotification(userId, notificationId));
     }
 
     @Test
@@ -165,7 +165,7 @@ class NotificationServiceImplTest {
         when(userRepository.existsById(userId)).thenReturn(true);
 
         // when
-        notificationService.readAllNotifications(userId);
+        notificationService.confirmAllNotifications(userId);
 
         // then
         verify(notificationRepository).confirmAllByUserId(userId);
@@ -179,6 +179,6 @@ class NotificationServiceImplTest {
 
         // when & then
         assertThrows(RuntimeException.class,
-            () -> notificationService.readAllNotifications(userId));
+            () -> notificationService.confirmAllNotifications(userId));
     }
 }

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImplTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImplTest.java
@@ -112,7 +112,7 @@ class NotificationServiceImplTest {
             () -> notificationService.createCommentNotification(comment, author, liker));
     }
 
-    @DisplayName("내 댓글에 좋아요 눌리면 알림 생성 - 실패: 유저 검증 실패")
+    @DisplayName("내 댓글에 좋아요 눌리면 알림 생성 - 실패: 유저1 검증 실패")
     @Test
     void createCommentNotificationShouldFail2() {
         // given
@@ -126,6 +126,29 @@ class NotificationServiceImplTest {
         when(commentRepository.existsById(commentId)).thenReturn(true);
         when(author.getId()).thenReturn(authorId);
         when(userRepository.existsById(authorId)).thenReturn(false);
+
+        // when & then
+        assertThrows(RuntimeException.class,
+            () -> notificationService.createCommentNotification(comment, author, liker));
+    }
+
+    @DisplayName("내 댓글에 좋아요 눌리면 알림 생성 - 실패: 유저2 검증 실패")
+    @Test
+    void createCommentNotificationShouldFail3() {
+        // given
+        UUID commentId = UUID.randomUUID();
+        Comment comment = mock(Comment.class);
+        UUID authorId = UUID.randomUUID();
+        User author = mock(User.class);
+        UUID likerId = UUID.randomUUID();
+        User liker = mock(User.class);
+
+        when(comment.getId()).thenReturn(commentId);
+        when(commentRepository.existsById(commentId)).thenReturn(true);
+        when(author.getId()).thenReturn(authorId);
+        when(userRepository.existsById(authorId)).thenReturn(true);
+        when(liker.getId()).thenReturn(likerId);
+        when(userRepository.existsById(likerId)).thenReturn(false);
 
         // when & then
         assertThrows(RuntimeException.class,
@@ -299,5 +322,17 @@ class NotificationServiceImplTest {
         assertNull(result.nextCursor());
         verify(notificationRepository).findFirstPage(any(), any());
         verify(notificationRepository).countForPagination(any());
+    }
+
+    @DisplayName("알림 목록 조회 - 실패: 유저 검증 실패")
+    @Test
+    void findAllShouldFail() {
+        // given
+        UUID userId = UUID.randomUUID();
+        when(userRepository.existsById(userId)).thenReturn(false);
+
+        // when & then
+        assertThrows(RuntimeException.class,
+            () -> notificationService.findAll(userId, null, null, 50));
     }
 }

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImplTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImplTest.java
@@ -1,7 +1,9 @@
 package com.codeit.team2.monew.module.domain.notification.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -13,9 +15,13 @@ import static org.mockito.Mockito.when;
 
 import com.codeit.team2.monew.module.domain.article.entity.Article;
 import com.codeit.team2.monew.module.domain.comment.entity.Comment;
+import com.codeit.team2.monew.module.domain.comment.repository.CommentRepository;
 import com.codeit.team2.monew.module.domain.interest.entity.Interest;
+import com.codeit.team2.monew.module.domain.notification.dto.CursorPageResponseNotificationDto;
+import com.codeit.team2.monew.module.domain.notification.dto.NotificationDto;
 import com.codeit.team2.monew.module.domain.notification.entity.Notification;
 import com.codeit.team2.monew.module.domain.notification.entity.ResourceType;
+import com.codeit.team2.monew.module.domain.notification.mapper.NotificationMapper;
 import com.codeit.team2.monew.module.domain.notification.repository.NotificationRepository;
 import com.codeit.team2.monew.module.domain.relation.entity.ArticleInterest;
 import com.codeit.team2.monew.module.domain.subscription.entity.Subscription;
@@ -26,11 +32,14 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -39,13 +48,17 @@ class NotificationServiceImplTest {
     @Mock
     private NotificationRepository notificationRepository;
     @Mock
+    private CommentRepository commentRepository;
+    @Mock
     private UserRepository userRepository;
     @Mock
     private SubscriptionRepository subscriptionRepository;
-
+    @Mock
+    private NotificationMapper notificationMapper;
     @InjectMocks
     private NotificationServiceImpl notificationService;
 
+    @DisplayName("내 댓글에 좋아요 눌리면 알림 생성 - 성공")
     @Test
     void createCommentNotification() {
         // given
@@ -67,6 +80,7 @@ class NotificationServiceImplTest {
         });
         when(userRepository.existsById(authorId)).thenReturn(true);
         when(userRepository.existsById(likerId)).thenReturn(true);
+        when(commentRepository.existsById(commentId)).thenReturn(true);
 
         // when
         Notification
@@ -81,6 +95,7 @@ class NotificationServiceImplTest {
         assertEquals(ResourceType.COMMENT, notification.getResourceType());
     }
 
+    @DisplayName("구독한 관심사 관련 기사가 등록되면 알림 생성 - 성공")
     @Test
     void createInterestNotification() {
 
@@ -119,8 +134,9 @@ class NotificationServiceImplTest {
         verify(notificationRepository, times(1)).saveAll(anyList());
     }
 
+    @DisplayName("알림 확인 - 성공")
     @Test
-    void readNotification() {
+    void confirmNotification() {
         // given
         UUID notificationId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
@@ -139,8 +155,9 @@ class NotificationServiceImplTest {
         assertEquals(true, notification.isConfirmed());
     }
 
+    @DisplayName("알림 확인 - 실패")
     @Test
-    void readNotificationShouldFail() {
+    void confirmNotificationShouldFail() {
         // given
         UUID notificationId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
@@ -157,8 +174,9 @@ class NotificationServiceImplTest {
             () -> notificationService.confirmNotification(userId, notificationId));
     }
 
+    @DisplayName("알림 전체 확인 - 성공")
     @Test
-    void readAllNotifications() {
+    void confirmAllNotifications() {
         // given
         UUID userId = UUID.randomUUID();
         User user = mock(User.class);
@@ -171,8 +189,9 @@ class NotificationServiceImplTest {
         verify(notificationRepository).confirmAllByUserId(userId);
     }
 
+    @DisplayName("알림 전체 확인 - 실패")
     @Test
-    void readAllNotificationsShouldFail() {
+    void confirmAllNotificationsShouldFail() {
         // given
         UUID userId = UUID.randomUUID();
         when(userRepository.existsById(userId)).thenReturn(false);
@@ -180,5 +199,43 @@ class NotificationServiceImplTest {
         // when & then
         assertThrows(RuntimeException.class,
             () -> notificationService.confirmAllNotifications(userId));
+    }
+
+    @DisplayName("알림 목록 조회 - 성공")
+    @Test
+    void findAll() {
+        // given
+        User user = mock(User.class);
+        UUID userId = UUID.randomUUID();
+        when(userRepository.existsById(userId)).thenReturn(true);
+
+        Notification n1 = new Notification(user, "content", UUID.randomUUID(),
+            ResourceType.COMMENT);
+        Notification n2 = new Notification(user, "content", UUID.randomUUID(),
+            ResourceType.COMMENT);
+        Page<Notification> pages = new PageImpl<>(List.of(n1, n2));
+        when(notificationRepository.findFirstPage(any(), any())).thenReturn(pages);
+        when(notificationRepository.countForPagination(userId)).thenReturn(2L);
+        when(notificationMapper.toDto(any(Notification.class))).thenAnswer(invocation -> {
+            Notification notification = invocation.getArgument(0);
+            NotificationDto notificationDto = new NotificationDto(notification.getId(),
+                notification.getCreatedAt(), notification.getUpdatedAt(),
+                notification.isConfirmed(), userId, notification.getContent(),
+                notification.getResourceType(), notification.getResourceId());
+            return notificationDto;
+        });
+        // when
+        CursorPageResponseNotificationDto result = notificationService.findAll(userId, null, null,
+            5);
+
+        // then
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertEquals(2L, result.totalElements());
+        assertFalse(result.hasNext());
+        assertNull(result.nextCursor());
+        assertNull(result.nextCursor());
+        verify(notificationRepository).findFirstPage(any(), any());
+        verify(notificationRepository).countForPagination(any());
     }
 }


### PR DESCRIPTION
## 구현 내용
알림 전체 목록 조회 페이지네이션 구현
- 확인하지 않은 알림만 조회합니다.
- 시간 순으로 정렬 및 커서 페이지네이션을 구현합니다.

### 구현된 API 엔드포인트
<!-- 구현한 API 엔드포인트 목록을 작성해주세요 -->
<!-- 예시:
- GET /api/notifications - 전체 알림 조회



### 주요 변경사항
<!-- 주요 변경사항을 작성해주세요 -->
- 알림 목록 조회 API 추가
- 로그 추가
- 

## 테스트 완료 사항
<!-- 테스트한 항목에 체크(x)해주세요 -->
- [x] 단위 테스트
- [ ] 통합 테스트
- [x] API 테스트 (Swagger/Postman 등)
- [ ] 기타 테스트

## 스크린샷
<!-- 필요한 경우 관련 스크린샷을 첨부해주세요 -->

## 체크리스트
<!-- 제출 전 확인해야 할 사항들입니다 -->
- [x] 코딩, 커밋 컨벤션 준수
- [x] 모든 테스트 통과
- [x] API 명세 준수
- [x] 불필요한 로그, 주석, 미사용 코드 제거

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #68

## 추가 코멘트 (선택)
<!-- 리뷰어에게 전달할 추가 정보가 있다면 작성해주세요 -->

알림은 createdAt을 기준으로 정렬됩니다.
저는 createdAt이 중복될 수도 있다고 생각하여 고유키인 id를 보조 커서로 사용할까 생각했는데
API 명세서와 프로토타입에서 cursor와 after 타입이 모두 Instant형을 쓰고 있어(createdAt 중복이 없다고 가정하는 듯 합니다) 고민이 됩니다.

일단 돌아가는 걸 확인하는 게 목적이라
queryDsl을 적용하는 건 리팩토링 단계에서 하겠습니다.