### PR TITLE
feat: 알림 생성 기능 #83

### DIFF
--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/batch/BatchArticleWriter.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/batch/BatchArticleWriter.java
@@ -4,6 +4,7 @@ import com.codeit.team2.monew.module.domain.article.dto.ArticleInterestCreateCom
 import com.codeit.team2.monew.module.domain.article.entity.Article;
 import com.codeit.team2.monew.module.domain.article.repository.ArticleRepository;
 import com.codeit.team2.monew.module.domain.interest.entity.Interest;
+import com.codeit.team2.monew.module.domain.notification.service.NotificationService;
 import com.codeit.team2.monew.module.domain.relation.entity.ArticleInterest;
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -27,6 +28,7 @@ public class BatchArticleWriter implements ItemWriter<List<ArticleInterestCreate
 
     private final ArticleRepository articleRepository;
     private final JdbcTemplate jdbcTemplate;
+    private final NotificationService notificationService;
 
     @Override
     public void write(Chunk<? extends List<ArticleInterestCreateCommand>> items) throws Exception {
@@ -78,6 +80,19 @@ public class BatchArticleWriter implements ItemWriter<List<ArticleInterestCreate
             ps.setObject(3, ai.getInterest().getId());
             ps.setObject(4, Timestamp.from(now));
         });
+
+        // 알림 생성
+        Set<UUID> newlySavedArticleIds = toSave.stream()
+            .map(Article::getId)
+            .collect(Collectors.toSet());
+        // 새롭게 등록된 기사(toSave)만 필터링
+        List<ArticleInterest> newlyCreatedInterests = articleInterests.stream()
+            .filter(ai -> newlySavedArticleIds.contains(ai.getArticle().getId()))
+            .toList();
+
+        if (!newlyCreatedInterests.isEmpty()) {
+            notificationService.createArticleInterestNotification(newlyCreatedInterests);
+        }
     }
 
     private List<ArticleInterestCreateCommand> flattenChunk(

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/service/CommentLikeServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/service/CommentLikeServiceImpl.java
@@ -4,6 +4,7 @@ import com.codeit.team2.monew.module.domain.comment.entity.Comment;
 import com.codeit.team2.monew.module.domain.comment.entity.CommentLike;
 import com.codeit.team2.monew.module.domain.comment.repository.CommentLikeRepository;
 import com.codeit.team2.monew.module.domain.comment.repository.CommentRepository;
+import com.codeit.team2.monew.module.domain.notification.service.NotificationService;
 import com.codeit.team2.monew.module.domain.user.entity.User;
 import com.codeit.team2.monew.module.domain.user.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -22,6 +23,7 @@ public class CommentLikeServiceImpl implements CommentLikeService {
     private final CommentRepository commentRepository;
     private final CommentLikeRepository commentLikeRepository;
     private final UserRepository userRepository;
+    private final NotificationService notificationService;
 
     @Override
     public CommentLike like(UUID commentId, UUID userId) {
@@ -45,6 +47,9 @@ public class CommentLikeServiceImpl implements CommentLikeService {
 
         CommentLike commentLike = CommentLike.create(comment, user);
         comment.incrementLikeCount();
+
+        // 알림 생성
+        notificationService.createCommentNotification(comment, comment.getUser(), user);
 
         return commentLikeRepository.save(commentLike);
     }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/service/NotificationService.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/service/NotificationService.java
@@ -1,9 +1,9 @@
 package com.codeit.team2.monew.module.domain.notification.service;
 
-import com.codeit.team2.monew.module.domain.article.entity.Article;
 import com.codeit.team2.monew.module.domain.comment.entity.Comment;
 import com.codeit.team2.monew.module.domain.notification.dto.CursorPageResponseNotificationDto;
 import com.codeit.team2.monew.module.domain.notification.entity.Notification;
+import com.codeit.team2.monew.module.domain.relation.entity.ArticleInterest;
 import com.codeit.team2.monew.module.domain.user.entity.User;
 import java.time.Instant;
 import java.util.List;
@@ -15,7 +15,7 @@ public interface NotificationService {
     Notification createCommentNotification(Comment comment, User author, User liker);
 
     // 구독한 관심사와 관련된 기사가 새로 등록된 경우
-    List<Notification> createInterestNotification(List<Article> articles);
+    List<Notification> createArticleInterestNotification(List<ArticleInterest> articleInterests);
 
     // 개별 알림 확인
     void confirmNotification(UUID userID, UUID notificationId);

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImpl.java
@@ -10,6 +10,7 @@ import com.codeit.team2.monew.module.domain.notification.entity.Notification;
 import com.codeit.team2.monew.module.domain.notification.entity.ResourceType;
 import com.codeit.team2.monew.module.domain.notification.mapper.NotificationMapper;
 import com.codeit.team2.monew.module.domain.notification.repository.NotificationRepository;
+import com.codeit.team2.monew.module.domain.relation.entity.ArticleInterest;
 import com.codeit.team2.monew.module.domain.subscription.entity.Subscription;
 import com.codeit.team2.monew.module.domain.subscription.repository.SubscriptionRepository;
 import com.codeit.team2.monew.module.domain.user.entity.User;
@@ -29,6 +30,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -42,7 +44,7 @@ public class NotificationServiceImpl implements NotificationService {
     private final SubscriptionRepository subscriptionRepository;
     private final NotificationMapper notificationMapper;
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Override
     public Notification createCommentNotification(Comment comment, User author, User liker) {
         if (!commentRepository.existsById(comment.getId())) {
@@ -66,33 +68,36 @@ public class NotificationServiceImpl implements NotificationService {
         return notification;
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Override
-    public List<Notification> createInterestNotification(List<Article> articles) {
+    public List<Notification> createArticleInterestNotification(
+        List<ArticleInterest> articleInterests) {
+        Map<Interest, List<Article>> interestToArticles = new HashMap<>();
+
+        for (ArticleInterest ai : articleInterests) {
+            Interest interest = ai.getInterest();
+            interestToArticles.computeIfAbsent(interest, k -> new ArrayList<>())
+                .add(ai.getArticle());
+        }
+
         List<Notification> notifications = new ArrayList<>();
 
-        // 관심사별 새로 등록된 기사 수 세기
-        Map<Interest, Integer> interestCount = new HashMap<>();
+        for (Map.Entry<Interest, List<Article>> entry : interestToArticles.entrySet()) {
+            Interest interest = entry.getKey();
+            List<Article> articles = entry.getValue();
 
-        articles.stream()
-            .flatMap(article -> article.getArticleInterests().stream())
-            .map(articleInterest -> articleInterest.getInterest())
-            .forEach(interest -> {
-                interestCount.put(interest, interestCount.getOrDefault(interest, 0) + 1);
-            });
+            String content = interest.getName() + "와 관련된 기사가 " + articles.size() + "건 등록되었습니다.";
 
-        interestCount.keySet().stream()
-            .forEach(interest -> {
-                String content =
-                    interest.getName() + "와 관련된 기사가 " + interestCount.get(interest) + "건 등록되었습니다.";
-                // 관심사를 구독한 유저별 알림 생성
-                List<Subscription> subscriptions = subscriptionRepository.findAllByInterest(
-                    interest);
-                for (Subscription sub : subscriptions) {
-                    notifications.add(new Notification(sub.getUser(), content,
-                        interest.getId(), ResourceType.INTEREST));
-                }
-            });
+            List<Subscription> subscriptions = subscriptionRepository.findAllByInterest(interest);
+
+            for (Subscription sub : subscriptions) {
+                notifications.add(new Notification(
+                    sub.getUser(), content,
+                    interest.getId(), ResourceType.INTEREST
+                ));
+            }
+        }
+
         notificationRepository.saveAll(notifications);
         return notifications;
     }

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/article/batch/BatchArticleWriterTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/article/batch/BatchArticleWriterTest.java
@@ -9,6 +9,7 @@ import com.codeit.team2.monew.module.domain.article.dto.ArticleInterestCreateCom
 import com.codeit.team2.monew.module.domain.article.entity.Article;
 import com.codeit.team2.monew.module.domain.article.repository.ArticleRepository;
 import com.codeit.team2.monew.module.domain.interest.entity.Interest;
+import com.codeit.team2.monew.module.domain.notification.service.NotificationService;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
@@ -29,11 +30,13 @@ public class BatchArticleWriterTest {
     private ArticleRepository articleRepository;
     @Mock
     private JdbcTemplate jdbcTemplate;
+    @Mock
+    private NotificationService notificationService;
     private BatchArticleWriter writer;
 
     @BeforeEach
     void setup() {
-        writer = new BatchArticleWriter(articleRepository, jdbcTemplate);
+        writer = new BatchArticleWriter(articleRepository, jdbcTemplate, notificationService);
     }
 
 

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/comment/service/CommentLikeServiceImplTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/comment/service/CommentLikeServiceImplTest.java
@@ -11,6 +11,7 @@ import com.codeit.team2.monew.module.domain.comment.entity.Comment;
 import com.codeit.team2.monew.module.domain.comment.entity.CommentLike;
 import com.codeit.team2.monew.module.domain.comment.repository.CommentLikeRepository;
 import com.codeit.team2.monew.module.domain.comment.repository.CommentRepository;
+import com.codeit.team2.monew.module.domain.notification.service.NotificationService;
 import com.codeit.team2.monew.module.domain.user.entity.User;
 import com.codeit.team2.monew.module.domain.user.repository.UserRepository;
 import java.util.Optional;
@@ -34,6 +35,9 @@ class CommentLikeServiceImplTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private NotificationService notificationService;
 
     @InjectMocks
     private CommentLikeServiceImpl commentLikeService;

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImplTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImplTest.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -30,7 +29,6 @@ import com.codeit.team2.monew.module.domain.user.entity.User;
 import com.codeit.team2.monew.module.domain.user.repository.UserRepository;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -155,44 +153,6 @@ class NotificationServiceImplTest {
             () -> notificationService.createCommentNotification(comment, author, liker));
     }
 
-    @DisplayName("구독한 관심사 관련 기사가 등록되면 알림 생성 - 성공")
-    @Test
-    void createInterestNotification() {
-
-        // given
-        Interest interest = mock(Interest.class);
-        UUID interestId = UUID.randomUUID();
-        when(interest.getId()).thenReturn(interestId);
-        when(interest.getName()).thenReturn("AI");
-
-        User user = mock(User.class);
-        Subscription subscription = mock(Subscription.class);
-        when(subscription.getUser()).thenReturn(user);
-
-        Article article = mock(Article.class);
-        ArticleInterest articleInterest = mock(ArticleInterest.class);
-        when(articleInterest.getInterest()).thenReturn(interest);
-        article.getArticleInterests().add(articleInterest);
-        when(article.getArticleInterests()).thenReturn(Set.of(articleInterest));
-        when(articleInterest.getInterest()).thenReturn(interest);
-
-        when(subscriptionRepository.findAllByInterest(interest))
-            .thenReturn(List.of(subscription));
-        when(notificationRepository.saveAll(anyList()))
-            .thenAnswer(invocation -> invocation.getArgument(0)); // 저장된 알림 그대로 리턴
-
-        // when
-        List<Notification> result = notificationService.createInterestNotification(
-            List.of(article));
-
-        // then
-        assertEquals(1, result.size());
-        Notification notification = result.get(0);
-        assertEquals(user, notification.getUser());
-        assertTrue(notification.getContent().contains("AI"));
-        verify(subscriptionRepository, times(1)).findAllByInterest(interest);
-        verify(notificationRepository, times(1)).saveAll(anyList());
-    }
 
     @DisplayName("알림 확인 - 성공")
     @Test
@@ -273,7 +233,7 @@ class NotificationServiceImplTest {
         // then
         verify(notificationRepository).confirmAllByUserId(userId);
     }
-
+    
     @DisplayName("알림 전체 확인 - 실패")
     @Test
     void confirmAllNotificationsShouldFail() {
@@ -334,5 +294,43 @@ class NotificationServiceImplTest {
         // when & then
         assertThrows(RuntimeException.class,
             () -> notificationService.findAll(userId, null, null, 50));
+    }
+
+    @DisplayName("구독한 관심사 관련 기사 등록 시 알림 생성 - 성공")
+    @Test
+    void createArticleInterestNotification() {
+
+        Interest interest = mock(Interest.class);
+        UUID interestId = UUID.randomUUID();
+        when(interest.getId()).thenReturn(interestId);
+        when(interest.getName()).thenReturn("AI");
+
+        User user = mock(User.class);
+        Subscription subscription = mock(Subscription.class);
+        when(subscription.getUser()).thenReturn(user);
+
+        Article article = mock(Article.class);
+        ArticleInterest articleInterest = mock(ArticleInterest.class);
+        when(articleInterest.getInterest()).thenReturn(interest);
+        article.getArticleInterests().add(articleInterest);
+        when(articleInterest.getInterest()).thenReturn(interest);
+        when(articleInterest.getArticle()).thenReturn(article);
+
+        when(subscriptionRepository.findAllByInterest(interest))
+            .thenReturn(List.of(subscription));
+        when(notificationRepository.saveAll(anyList()))
+            .thenAnswer(invocation -> invocation.getArgument(0)); // 저장된 알림 그대로 리턴
+
+        // when
+        List<Notification> result = notificationService.createArticleInterestNotification(
+            List.of(articleInterest));
+
+        // then
+        assertEquals(1, result.size());
+        Notification notification = result.get(0);
+        assertEquals(user, notification.getUser());
+        assertTrue(notification.getContent().contains("AI"));
+        verify(subscriptionRepository).findAllByInterest(interest);
+        verify(notificationRepository).saveAll(anyList());
     }
 }


### PR DESCRIPTION
## 구현 내용
알림 생성 기능

- 구독한 관심사 관련 기사가 등록될 때
- 내 댓글에 좋아요가 눌릴 때

### 구현된 API 엔드포인트
<!-- 구현한 API 엔드포인트 목록을 작성해주세요 -->

미해당


### 주요 변경사항
<!-- 주요 변경사항을 작성해주세요 -->
- NotificationServiceImpl에서 '구독한 관심사 관련 기사 등록 시 알림 생성'을 새로운 메소드로 구현
- CommentServiceImpl, BatchArticleWriter에 알림 생성 기능 호출 코드 추가
- 

## 테스트 완료 사항
<!-- 테스트한 항목에 체크(x)해주세요 -->
- [x] 단위 테스트
- [ ] 통합 테스트
- [x] API 테스트 (Swagger/Postman 등)
- [ ] 기타 테스트

## 스크린샷
<!-- 필요한 경우 관련 스크린샷을 첨부해주세요 -->

## 체크리스트
<!-- 제출 전 확인해야 할 사항들입니다 -->
- [x] 코딩, 커밋 컨벤션 준수
- [x] 모든 테스트 통과
- [ ] API 명세 준수
- [x] 불필요한 로그, 주석, 미사용 코드 제거

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #83  #23 

## 추가 코멘트 (선택)
<!-- 리뷰어에게 전달할 추가 정보가 있다면 작성해주세요 -->


- 구독한 관심사 관련 기사가 등록될 때
- 내 댓글에 좋아요가 눌릴 때

이 두 가지 경우에 알림을 생성하기 위해
각 코드에 NotificationService 의존성을 추가하고, 적절한 메소드를 호출하는 코드를 추가하였습니다.
테스트 코드에도 @Mock으로 추가하여 테스트 통과 확인했습니다.

---

📌 댓글에 좋아요가 눌리는 경우는 postman으로 api 호출하여 DB에 CommentLike와 함께 Notification도 함께 생성되는지 확인하였습니다.
📌 기사 등록되는 경우에는 Batch job을 돌리면서 봤는데 기사 데이터가 한 번에 몇 천건씩 등록되는 바람에, 알림에서 새로 등록된 기사의 수를 정확히 세고 있는지 확신하기 힘드네요 일단 알림 생성에서 카운트된 수와 기사 수가 얼추 맞기에 넘어갔습니다 😅 좋은 테스트 방법 아이디어 있을까요?

---

🚀 @Kiki1875b BatchArticleWriter에서 코드를 제가 제대로 이해하고 활용했는지 한 번 봐주시면 감사하겠습니다.
```articleInterests```는 이전에 생성된 기사(existing)와 새롭게 생성된 기사(toSave) 정보를 모두 포함하고 있다고 생각하여 새롭게 생성된 기사 정보만 알림 생성할 수 있도록 ```newlySavedArticleIds, newlyCreatedInterests```으로 분리하는 작업을 거쳤습니다.

## TODO

알림이 역시 createdAt이 중복될 수 있는 것 같아
나중에 커서 페이지네이션은 id를 보조 커서로 쓰는 방향으로 수정해야 할 것 같습니다.
