### PR TITLE
feat: mongodb 연동 및 관련 Document 정의

### DIFF
--- a/monew/build.gradle
+++ b/monew/build.gradle
@@ -64,6 +64,7 @@ dependencies {
 
     testImplementation 'org.springframework.batch:spring-batch-test'
 
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 
     // TestContainer
     testImplementation 'org.testcontainers:junit-jupiter'

--- a/monew/src/main/java/com/codeit/team2/monew/config/MongoDbConfig.java
+++ b/monew/src/main/java/com/codeit/team2/monew/config/MongoDbConfig.java
@@ -1,8 +1,10 @@
 package com.codeit.team2.monew.config;
 
+import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
-@EnableMongoRepositories
+@Configuration
+@EnableMongoRepositories(basePackages = "com.codeit.team2.monew.module.domain.useractivity.repository")
 public class MongoDbConfig {
 
 }

--- a/monew/src/main/java/com/codeit/team2/monew/config/MongoDbConfig.java
+++ b/monew/src/main/java/com/codeit/team2/monew/config/MongoDbConfig.java
@@ -1,0 +1,8 @@
+package com.codeit.team2.monew.config;
+
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+
+@EnableMongoRepositories
+public class MongoDbConfig {
+
+}

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/repository/ArticleViewRepository.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/repository/ArticleViewRepository.java
@@ -6,11 +6,13 @@ import com.codeit.team2.monew.module.domain.user.entity.User;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ArticleViewRepository extends JpaRepository<ArticleView, UUID> {
 
     Optional<ArticleView> findByUserAndArticle(User user, Article article);
 
+    @EntityGraph(attributePaths = {"article", "user"})
     List<ArticleView> findTop10ByUserOrderByViewedAtDesc(User user);
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/repository/CommentLikeRepository.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/repository/CommentLikeRepository.java
@@ -5,6 +5,7 @@ import com.codeit.team2.monew.module.domain.user.entity.User;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentLikeRepository extends JpaRepository<CommentLike, UUID> {
@@ -13,6 +14,11 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, UUID> 
 
     Optional<CommentLike> findByCommentIdAndUserId(UUID commentId, UUID userId);
 
+    @EntityGraph(attributePaths = {
+        "comment",
+        "comment.article",
+        "comment.user"
+    })
     List<CommentLike> findTop10ByUserOrderByLikedAtDesc(User user);
 
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/repository/CommentRepository.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/repository/CommentRepository.java
@@ -5,10 +5,12 @@ import com.codeit.team2.monew.module.domain.comment.entity.Comment;
 import com.codeit.team2.monew.module.domain.user.entity.User;
 import java.util.List;
 import java.util.UUID;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, UUID> {
 
+    @EntityGraph(attributePaths = {"article"})
     List<Comment> findTop10ByUserOrderByCreatedAtDesc(User user);
 
     Long countByArticle(Article article);

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/user/TestDataInitializer.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/user/TestDataInitializer.java
@@ -1,74 +1,75 @@
-package com.codeit.team2.monew.module.domain.user;
-
-import com.codeit.team2.monew.module.domain.article.entity.Article;
-import com.codeit.team2.monew.module.domain.article.entity.ArticleView;
-import com.codeit.team2.monew.module.domain.article.repository.ArticleRepository;
-import com.codeit.team2.monew.module.domain.article.repository.ArticleViewRepository;
-import com.codeit.team2.monew.module.domain.comment.entity.Comment;
-import com.codeit.team2.monew.module.domain.comment.entity.CommentLike;
-import com.codeit.team2.monew.module.domain.comment.repository.CommentLikeRepository;
-import com.codeit.team2.monew.module.domain.comment.repository.CommentRepository;
-import com.codeit.team2.monew.module.domain.subscription.repository.SubscriptionRepository;
-import com.codeit.team2.monew.module.domain.user.entity.User;
-import com.codeit.team2.monew.module.domain.user.repository.UserRepository;
-import jakarta.annotation.PostConstruct;
-import java.time.Instant;
-import java.util.Set;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
-
-@Component
-@RequiredArgsConstructor
-public class TestDataInitializer {
-
-    private final UserRepository userRepository;
-    private final SubscriptionRepository subscriptionRepository;
-    private final CommentRepository commentRepository;
-    private final CommentLikeRepository commentLikeRepository;
-    private final ArticleRepository articleRepository;
-    private final ArticleViewRepository articleViewRepository;
-
-
-    @PostConstruct
-    void init() {
-        User user = userRepository.save(
-            new User("email@a.com", "nickname", "passowrd", false)
-        );
-
-        // 3. 기사 & 댓글 & 좋아요 & 조회 기록 생성
-        for (int i = 0; i < 20; i++) {
-            Article article = new Article(
-                "title" + i,
-                "NAVER",
-                "sourceUrl" + i,
-                "summary" + i,
-                Set.of(),
-                0,
-                Instant.now(),
-                false
-            );
-            articleRepository.save(article);
-
-            Comment comment = Comment.create(
-                article,
-                user,
-                "content" + i
-            );
-            commentRepository.save(comment);
-
-            CommentLike commentLike = CommentLike.create(
-                comment,
-                user
-            );
-            commentLikeRepository.save(commentLike);
-
-            ArticleView articleView = new ArticleView(
-                user,
-                article,
-                Instant.now()
-            );
-            articleViewRepository.save(articleView);
-        }
-    }
-
-}
+//package com.codeit.team2.monew.module.domain.user;
+//
+//import com.codeit.team2.monew.module.domain.article.entity.Article;
+//import com.codeit.team2.monew.module.domain.article.entity.ArticleView;
+//import com.codeit.team2.monew.module.domain.article.repository.ArticleRepository;
+//import com.codeit.team2.monew.module.domain.article.repository.ArticleViewRepository;
+//import com.codeit.team2.monew.module.domain.comment.entity.Comment;
+//import com.codeit.team2.monew.module.domain.comment.entity.CommentLike;
+//import com.codeit.team2.monew.module.domain.comment.repository.CommentLikeRepository;
+//import com.codeit.team2.monew.module.domain.comment.repository.CommentRepository;
+//import com.codeit.team2.monew.module.domain.subscription.repository.SubscriptionRepository;
+//import com.codeit.team2.monew.module.domain.user.entity.User;
+//import com.codeit.team2.monew.module.domain.user.repository.UserRepository;
+//import jakarta.annotation.PostConstruct;
+//import java.time.Instant;
+//import java.util.Set;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.stereotype.Component;
+//
+//@Component
+//@RequiredArgsConstructor
+//public class TestDataInitializer {
+//
+//    private final UserRepository userRepository;
+//    private final SubscriptionRepository subscriptionRepository;
+//    private final CommentRepository commentRepository;
+//    private final CommentLikeRepository commentLikeRepository;
+//    private final ArticleRepository articleRepository;
+//    private final ArticleViewRepository articleViewRepository;
+//
+//
+//    @PostConstruct
+//    void init() {
+//        User user = userRepository.save(
+//            new User("email@a.com", "nickname", "passowrd", false)
+//        );
+//
+//        // 3. 기사 & 댓글 & 좋아요 & 조회 기록 생성
+//        for (int i = 0; i < 20; i++) {
+//            Article article = new Article(
+//                "title" + i,
+//                "NAVER",
+//                "sourceUrl" + i,
+//                "summary" + i,
+//                Set.of(),
+//                0L,
+//                Instant.now(),
+//                false
+//            );
+//            articleRepository.save(article);
+//
+//            Comment comment = Comment.create(
+//                article,
+//                user,
+//                "content" + i
+//            );
+//            comment.incrementLikeCount();
+//            commentRepository.save(comment);
+//
+//            CommentLike commentLike = CommentLike.create(
+//                comment,
+//                user
+//            );
+//            commentLikeRepository.save(commentLike);
+//
+//            ArticleView articleView = new ArticleView(
+//                user,
+//                article,
+//                Instant.now()
+//            );
+//            articleViewRepository.save(articleView);
+//        }
+//    }
+//
+//}

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/user/TestDataInitializer.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/user/TestDataInitializer.java
@@ -1,73 +1,74 @@
-//package com.codeit.team2.monew.module.domain.user;
-//
-//import com.codeit.team2.monew.module.domain.article.entity.Article;
-//import com.codeit.team2.monew.module.domain.article.entity.ArticleView;
-//import com.codeit.team2.monew.module.domain.article.repository.ArticleRepository;
-//import com.codeit.team2.monew.module.domain.article.repository.ArticleViewRepository;
-//import com.codeit.team2.monew.module.domain.comment.entity.Comment;
-//import com.codeit.team2.monew.module.domain.comment.entity.CommentLike;
-//import com.codeit.team2.monew.module.domain.comment.repository.CommentLikeRepository;
-//import com.codeit.team2.monew.module.domain.comment.repository.CommentRepository;
-//import com.codeit.team2.monew.module.domain.subscription.repository.SubscriptionRepository;
-//import com.codeit.team2.monew.module.domain.user.entity.User;
-//import com.codeit.team2.monew.module.domain.user.repository.UserRepository;
-//import jakarta.annotation.PostConstruct;
-//import java.time.Instant;
-//import java.util.Set;
-//import lombok.RequiredArgsConstructor;
-//
-//@Component
-//@RequiredArgsConstructor
-//public class TestDataInitializer {
-//
-//    private final UserRepository userRepository;
-//    private final SubscriptionRepository subscriptionRepository;
-//    private final CommentRepository commentRepository;
-//    private final CommentLikeRepository commentLikeRepository;
-//    private final ArticleRepository articleRepository;
-//    private final ArticleViewRepository articleViewRepository;
-//
-//
-//    @PostConstruct
-//    void init() {
-//        User user = userRepository.save(
-//            new User("email@a.com", "nickname", "passowrd", false)
-//        );
-//
-//        // 3. 기사 & 댓글 & 좋아요 & 조회 기록 생성
-//        for (int i = 0; i < 20; i++) {
-//            Article article = new Article(
-//                "title" + i,
-//                "NAVER",
-//                "sourceUrl" + i,
-//                "summary" + i,
-//                Set.of(),
-//                0,
-//                Instant.now(),
-//                false
-//            );
-//            articleRepository.save(article);
-//
-//            Comment comment = Comment.create(
-//                article,
-//                user,
-//                "content" + i
-//            );
-//            commentRepository.save(comment);
-//
-//            CommentLike commentLike = CommentLike.create(
-//                comment,
-//                user
-//            );
-//            commentLikeRepository.save(commentLike);
-//
-//            ArticleView articleView = new ArticleView(
-//                user,
-//                article,
-//                Instant.now()
-//            );
-//            articleViewRepository.save(articleView);
-//        }
-//    }
-//
-//}
+package com.codeit.team2.monew.module.domain.user;
+
+import com.codeit.team2.monew.module.domain.article.entity.Article;
+import com.codeit.team2.monew.module.domain.article.entity.ArticleView;
+import com.codeit.team2.monew.module.domain.article.repository.ArticleRepository;
+import com.codeit.team2.monew.module.domain.article.repository.ArticleViewRepository;
+import com.codeit.team2.monew.module.domain.comment.entity.Comment;
+import com.codeit.team2.monew.module.domain.comment.entity.CommentLike;
+import com.codeit.team2.monew.module.domain.comment.repository.CommentLikeRepository;
+import com.codeit.team2.monew.module.domain.comment.repository.CommentRepository;
+import com.codeit.team2.monew.module.domain.subscription.repository.SubscriptionRepository;
+import com.codeit.team2.monew.module.domain.user.entity.User;
+import com.codeit.team2.monew.module.domain.user.repository.UserRepository;
+import jakarta.annotation.PostConstruct;
+import java.time.Instant;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TestDataInitializer {
+
+    private final UserRepository userRepository;
+    private final SubscriptionRepository subscriptionRepository;
+    private final CommentRepository commentRepository;
+    private final CommentLikeRepository commentLikeRepository;
+    private final ArticleRepository articleRepository;
+    private final ArticleViewRepository articleViewRepository;
+
+
+    @PostConstruct
+    void init() {
+        User user = userRepository.save(
+            new User("email@a.com", "nickname", "passowrd", false)
+        );
+
+        // 3. 기사 & 댓글 & 좋아요 & 조회 기록 생성
+        for (int i = 0; i < 20; i++) {
+            Article article = new Article(
+                "title" + i,
+                "NAVER",
+                "sourceUrl" + i,
+                "summary" + i,
+                Set.of(),
+                0,
+                Instant.now(),
+                false
+            );
+            articleRepository.save(article);
+
+            Comment comment = Comment.create(
+                article,
+                user,
+                "content" + i
+            );
+            commentRepository.save(comment);
+
+            CommentLike commentLike = CommentLike.create(
+                comment,
+                user
+            );
+            commentLikeRepository.save(commentLike);
+
+            ArticleView articleView = new ArticleView(
+                user,
+                article,
+                Instant.now()
+            );
+            articleViewRepository.save(articleView);
+        }
+    }
+
+}

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/user/event/RegisterUserEvent.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/user/event/RegisterUserEvent.java
@@ -1,0 +1,9 @@
+package com.codeit.team2.monew.module.domain.user.event;
+
+import com.codeit.team2.monew.module.domain.user.entity.User;
+
+public record RegisterUserEvent(
+    User user
+) {
+
+}

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/user/service/UserServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/user/service/UserServiceImpl.java
@@ -23,6 +23,7 @@ public class UserServiceImpl implements UserService {
     private final ApplicationEventPublisher publisher;
 
     @Override
+    @Transactional
     public UserDto registerUser(UserRegisterRequest userRegisterRequest) {
         if (userRepository.existsByEmail(userRegisterRequest.email())) {
             throw new RuntimeException("duplicate email");

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/user/service/UserServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/user/service/UserServiceImpl.java
@@ -5,10 +5,12 @@ import com.codeit.team2.monew.module.domain.user.dto.request.UserRegisterRequest
 import com.codeit.team2.monew.module.domain.user.dto.request.UserUpdateRequest;
 import com.codeit.team2.monew.module.domain.user.dto.response.UserDto;
 import com.codeit.team2.monew.module.domain.user.entity.User;
+import com.codeit.team2.monew.module.domain.user.event.RegisterUserEvent;
 import com.codeit.team2.monew.module.domain.user.mapper.UserMapper;
 import com.codeit.team2.monew.module.domain.user.repository.UserRepository;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +20,7 @@ public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
     private final UserMapper userMapper;
+    private final ApplicationEventPublisher publisher;
 
     @Override
     public UserDto registerUser(UserRegisterRequest userRegisterRequest) {
@@ -32,6 +35,9 @@ public class UserServiceImpl implements UserService {
         // password 암호화는 추후 진행
 
         User user = userRepository.save(userMapper.toUser(userRegisterRequest));
+
+        // 사용자 생성 이벤트 발생
+        publisher.publishEvent(new RegisterUserEvent(user));
 
         return userMapper.toUserDto(user);
     }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/document/ArticleViewItem.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/document/ArticleViewItem.java
@@ -1,0 +1,28 @@
+package com.codeit.team2.monew.module.domain.useractivity.document;
+
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "article_views")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class ArticleViewItem {
+
+    private UUID id;
+    private UUID viewedBy;
+    private Instant createdAt;
+    private UUID articleId;
+    private String source;
+    private String sourceUrl;
+    private String articleTitle;
+    private Instant articlePublishedDate;
+    private String articleSummary;
+    private Long articleCommentCount;
+    private Long articleViewCount;
+}

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/document/CommentItem.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/document/CommentItem.java
@@ -1,0 +1,26 @@
+package com.codeit.team2.monew.module.domain.useractivity.document;
+
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "comments")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class CommentItem {
+
+    private UUID id;
+    private UUID articleId;
+    private String articleTitle;
+    private UUID userId;
+    private String userNickname;
+    private String content;
+    private Long likeCount;
+    private Instant createdAt;
+}
+

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/document/CommentLikeItem.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/document/CommentLikeItem.java
@@ -1,0 +1,27 @@
+package com.codeit.team2.monew.module.domain.useractivity.document;
+
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "comment_likes")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class CommentLikeItem {
+
+    private UUID id;
+    private Instant createdAt;
+    private UUID commentId;
+    private UUID articleId;
+    private String articleTitle;
+    private UUID commentUserId;
+    private String commentUserNickname;
+    private String commentContent;
+    private Long commentLikeCount;
+    private Instant commentCreatedAt;
+}

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/document/SubscriptionItem.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/document/SubscriptionItem.java
@@ -1,0 +1,25 @@
+package com.codeit.team2.monew.module.domain.useractivity.document;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "subscriptions")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class SubscriptionItem {
+
+    private UUID id;
+    private UUID interestId;
+    private String interestName;
+    private List<String> interestKeywords;
+    private Long interestSubscriberCount;
+    private Instant createdAt;
+}
+

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/document/UserActivity.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/document/UserActivity.java
@@ -1,0 +1,27 @@
+package com.codeit.team2.monew.module.domain.useractivity.document;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "user_activities")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class UserActivity {
+
+    private UUID id; // 사용자 아이디
+    private String email;
+    private String nickname;
+    private Instant createdAt;
+    private List<SubscriptionItem> subscriptions;
+    private List<CommentItem> comments;
+    private List<CommentLikeItem> commentLikes;
+    private List<ArticleViewItem> articleViews;
+}
+

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/dto/ArticleViewItemDto.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/dto/ArticleViewItemDto.java
@@ -3,7 +3,7 @@ package com.codeit.team2.monew.module.domain.useractivity.dto;
 import java.time.Instant;
 import java.util.UUID;
 
-public record ArticleViewItem(
+public record ArticleViewItemDto(
     UUID id,
     UUID viewedBy,
     Instant createdAt,

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/dto/CommentItemDto.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/dto/CommentItemDto.java
@@ -3,7 +3,7 @@ package com.codeit.team2.monew.module.domain.useractivity.dto;
 import java.time.Instant;
 import java.util.UUID;
 
-public record CommentItem(
+public record CommentItemDto(
     UUID id,
     UUID articleId,
     String articleTitle,

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/dto/CommentLikeItemDto.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/dto/CommentLikeItemDto.java
@@ -3,7 +3,7 @@ package com.codeit.team2.monew.module.domain.useractivity.dto;
 import java.time.Instant;
 import java.util.UUID;
 
-public record CommentLikeItem(
+public record CommentLikeItemDto(
     UUID id,
     Instant createdAt,
     UUID commentId,

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/dto/SubscriptionItemDto.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/dto/SubscriptionItemDto.java
@@ -4,7 +4,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
-public record SubscriptionItem(
+public record SubscriptionItemDto(
     UUID id,
     UUID interestId,
     String interestName,

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/dto/UserActivityDto.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/dto/UserActivityDto.java
@@ -9,10 +9,10 @@ public record UserActivityDto(
     String email,
     String nickname,
     Instant createdAt,
-    List<SubscriptionItem> subscriptions,
-    List<CommentItem> comments,
-    List<CommentLikeItem> commentLikes,
-    List<ArticleViewItem> articleViews
+    List<SubscriptionItemDto> subscriptions,
+    List<CommentItemDto> comments,
+    List<CommentLikeItemDto> commentLikes,
+    List<ArticleViewItemDto> articleViews
 ) {
 
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/listener/UserEventListener.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/listener/UserEventListener.java
@@ -3,8 +3,9 @@ package com.codeit.team2.monew.module.domain.useractivity.listener;
 import com.codeit.team2.monew.module.domain.user.event.RegisterUserEvent;
 import com.codeit.team2.monew.module.domain.useractivity.service.MongoUserActivityService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
@@ -12,7 +13,7 @@ public class UserEventListener {
 
     private final MongoUserActivityService userActivityService;
 
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void createUserActivity(RegisterUserEvent event) {
         userActivityService.createUserActivity(event.user());
     }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/listener/UserEventListener.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/listener/UserEventListener.java
@@ -3,12 +3,14 @@ package com.codeit.team2.monew.module.domain.useractivity.listener;
 import com.codeit.team2.monew.module.domain.user.event.RegisterUserEvent;
 import com.codeit.team2.monew.module.domain.useractivity.service.MongoUserActivityService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.db-type", havingValue = "mongodb")
 public class UserEventListener {
 
     private final MongoUserActivityService userActivityService;

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/listener/UserEventListener.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/listener/UserEventListener.java
@@ -1,0 +1,20 @@
+package com.codeit.team2.monew.module.domain.useractivity.listener;
+
+import com.codeit.team2.monew.module.domain.user.event.RegisterUserEvent;
+import com.codeit.team2.monew.module.domain.useractivity.service.MongoUserActivityService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserEventListener {
+
+    private final MongoUserActivityService userActivityService;
+
+    @EventListener
+    public void createUserActivity(RegisterUserEvent event) {
+        userActivityService.createUserActivity(event.user());
+    }
+
+}

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/mapper/UserActivityMapper.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/mapper/UserActivityMapper.java
@@ -62,10 +62,10 @@ public interface UserActivityMapper {
     @Mapping(source = "user.email", target = "email")
     @Mapping(source = "user.nickname", target = "nickname")
     @Mapping(source = "user.createdAt", target = "createdAt")
-    @Mapping(source = "subscriptionItems", target = "subscriptions")
-    @Mapping(source = "commentItems", target = "comments")
-    @Mapping(source = "commentLikeItems", target = "commentLikes")
-    @Mapping(source = "articleViewItems", target = "articleViews")
+    @Mapping(source = "subscriptionItemDtos", target = "subscriptions")
+    @Mapping(source = "commentItemDtos", target = "comments")
+    @Mapping(source = "commentLikeItemDtos", target = "commentLikes")
+    @Mapping(source = "articleViewItemDtos", target = "articleViews")
     UserActivityDto toUserActivityDto(
         User user,
         List<SubscriptionItemDto> subscriptionItemDtos,

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/mapper/UserActivityMapper.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/mapper/UserActivityMapper.java
@@ -1,7 +1,10 @@
 package com.codeit.team2.monew.module.domain.useractivity.mapper;
 
+import com.codeit.team2.monew.module.domain.article.entity.ArticleView;
+import com.codeit.team2.monew.module.domain.article.mapper.ArticleMapper;
 import com.codeit.team2.monew.module.domain.comment.entity.Comment;
 import com.codeit.team2.monew.module.domain.comment.entity.CommentLike;
+import com.codeit.team2.monew.module.domain.comment.repository.CommentRepository;
 import com.codeit.team2.monew.module.domain.interest.entity.InterestKeyword;
 import com.codeit.team2.monew.module.domain.subscription.entity.Subscription;
 import com.codeit.team2.monew.module.domain.user.entity.User;
@@ -15,10 +18,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", uses = {ArticleMapper.class})
 public interface UserActivityMapper {
 
     @Mapping(source = "id", target = "id")
@@ -76,4 +80,19 @@ public interface UserActivityMapper {
     );
 
     UserActivityDto toUserActivityDto(UserActivity userActivity);
+
+    @Mapping(source = "articleView.id", target = "id")
+    @Mapping(source = "articleView.user.id", target = "viewedBy")
+    @Mapping(source = "articleView.createdAt", target = "createdAt")
+    @Mapping(source = "articleView.article.id", target = "articleId")
+    @Mapping(source = "articleView.article.source", target = "source")
+    @Mapping(source = "articleView.article.sourceUrl", target = "sourceUrl")
+    @Mapping(source = "articleView.article.title", target = "articleTitle")
+    @Mapping(source = "articleView.article.publishedDate", target = "articlePublishedDate")
+    @Mapping(source = "articleView.article.summary", target = "articleSummary")
+    @Mapping(expression = "java(commentRepository.countByArticle(articleView.getArticle()))",
+        target = "articleCommentCount")
+    @Mapping(source = "articleView.article.viewCount", target = "articleViewCount")
+    ArticleViewItemDto toArticleViewItemDto(ArticleView articleView,
+        @Context CommentRepository commentRepository);
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/mapper/UserActivityMapper.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/mapper/UserActivityMapper.java
@@ -5,10 +5,10 @@ import com.codeit.team2.monew.module.domain.comment.entity.CommentLike;
 import com.codeit.team2.monew.module.domain.interest.entity.InterestKeyword;
 import com.codeit.team2.monew.module.domain.subscription.entity.Subscription;
 import com.codeit.team2.monew.module.domain.user.entity.User;
-import com.codeit.team2.monew.module.domain.useractivity.dto.ArticleViewItem;
-import com.codeit.team2.monew.module.domain.useractivity.dto.CommentItem;
-import com.codeit.team2.monew.module.domain.useractivity.dto.CommentLikeItem;
-import com.codeit.team2.monew.module.domain.useractivity.dto.SubscriptionItem;
+import com.codeit.team2.monew.module.domain.useractivity.dto.ArticleViewItemDto;
+import com.codeit.team2.monew.module.domain.useractivity.dto.CommentItemDto;
+import com.codeit.team2.monew.module.domain.useractivity.dto.CommentLikeItemDto;
+import com.codeit.team2.monew.module.domain.useractivity.dto.SubscriptionItemDto;
 import com.codeit.team2.monew.module.domain.useractivity.dto.UserActivityDto;
 import java.util.Collections;
 import java.util.List;
@@ -26,7 +26,7 @@ public interface UserActivityMapper {
     @Mapping(expression = "java((long) subscription.getInterest().getSubscriberCount())",
         target = "interestSubscriberCount")
     @Mapping(source = "interest.keywords", target = "interestKeywords")
-    SubscriptionItem toSubscriptionItem(Subscription subscription);
+    SubscriptionItemDto toSubscriptionItem(Subscription subscription);
 
     default List<String> mapInterestKeywords(Set<InterestKeyword> keywords) {
         if (keywords == null) {
@@ -45,7 +45,7 @@ public interface UserActivityMapper {
     @Mapping(source = "comment.content", target = "content")
     @Mapping(source = "comment.likeCount", target = "likeCount")
     @Mapping(source = "comment.createdAt", target = "createdAt")
-    CommentItem toCommentItem(User user, Comment comment);
+    CommentItemDto toCommentItem(User user, Comment comment);
 
     @Mapping(source = "id", target = "id")
     @Mapping(source = "comment.id", target = "commentId")
@@ -56,7 +56,7 @@ public interface UserActivityMapper {
     @Mapping(source = "comment.content", target = "commentContent")
     @Mapping(source = "comment.likeCount", target = "commentLikeCount")
     @Mapping(source = "comment.createdAt", target = "commentCreatedAt")
-    CommentLikeItem toCommentLikeItem(CommentLike commentLike);
+    CommentLikeItemDto toCommentLikeItem(CommentLike commentLike);
 
     @Mapping(source = "user.id", target = "id")
     @Mapping(source = "user.email", target = "email")
@@ -68,9 +68,9 @@ public interface UserActivityMapper {
     @Mapping(source = "articleViewItems", target = "articleViews")
     UserActivityDto toUserActivityDto(
         User user,
-        List<SubscriptionItem> subscriptionItems,
-        List<CommentItem> commentItems,
-        List<CommentLikeItem> commentLikeItems,
-        List<ArticleViewItem> articleViewItems
+        List<SubscriptionItemDto> subscriptionItemDtos,
+        List<CommentItemDto> commentItemDtos,
+        List<CommentLikeItemDto> commentLikeItemDtos,
+        List<ArticleViewItemDto> articleViewItemDtos
     );
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/mapper/UserActivityMapper.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/mapper/UserActivityMapper.java
@@ -5,6 +5,7 @@ import com.codeit.team2.monew.module.domain.comment.entity.CommentLike;
 import com.codeit.team2.monew.module.domain.interest.entity.InterestKeyword;
 import com.codeit.team2.monew.module.domain.subscription.entity.Subscription;
 import com.codeit.team2.monew.module.domain.user.entity.User;
+import com.codeit.team2.monew.module.domain.useractivity.document.UserActivity;
 import com.codeit.team2.monew.module.domain.useractivity.dto.ArticleViewItemDto;
 import com.codeit.team2.monew.module.domain.useractivity.dto.CommentItemDto;
 import com.codeit.team2.monew.module.domain.useractivity.dto.CommentLikeItemDto;
@@ -73,4 +74,6 @@ public interface UserActivityMapper {
         List<CommentLikeItemDto> commentLikeItemDtos,
         List<ArticleViewItemDto> articleViewItemDtos
     );
+
+    UserActivityDto toUserActivityDto(UserActivity userActivity);
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/repository/MongoUserActivityRepository.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/repository/MongoUserActivityRepository.java
@@ -1,0 +1,9 @@
+package com.codeit.team2.monew.module.domain.useractivity.repository;
+
+import com.codeit.team2.monew.module.domain.useractivity.document.UserActivity;
+import java.util.UUID;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface MongoUserActivityRepository extends MongoRepository<UserActivity, UUID> {
+
+}

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/service/MongoUserActivityService.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/service/MongoUserActivityService.java
@@ -3,6 +3,7 @@ package com.codeit.team2.monew.module.domain.useractivity.service;
 import com.codeit.team2.monew.module.domain.user.entity.User;
 import com.codeit.team2.monew.module.domain.useractivity.document.UserActivity;
 import com.codeit.team2.monew.module.domain.useractivity.dto.UserActivityDto;
+import com.codeit.team2.monew.module.domain.useractivity.mapper.UserActivityMapper;
 import com.codeit.team2.monew.module.domain.useractivity.repository.MongoUserActivityRepository;
 import java.util.Collections;
 import java.util.UUID;
@@ -16,10 +17,18 @@ import org.springframework.stereotype.Service;
 public class MongoUserActivityService implements UserActivityService {
 
     private final MongoUserActivityRepository userActivityRepository;
+    private final UserActivityMapper userActivityMapper;
 
     @Override
     public UserActivityDto findUserActivities(UUID loginId, UUID userId) {
-        return null;
+        if (!loginId.equals(userId)) {
+            throw new RuntimeException("Not Authorized");
+        }
+
+        UserActivity userActivity = userActivityRepository.findById(userId)
+            .orElseThrow(() -> new RuntimeException("Not Found UserActivity"));
+
+        return userActivityMapper.toUserActivityDto(userActivity);
     }
 
     public void createUserActivity(User user) {

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/service/MongoUserActivityService.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/service/MongoUserActivityService.java
@@ -1,10 +1,9 @@
 package com.codeit.team2.monew.module.domain.useractivity.service;
 
+import com.codeit.team2.monew.module.domain.user.entity.User;
 import com.codeit.team2.monew.module.domain.useractivity.document.UserActivity;
 import com.codeit.team2.monew.module.domain.useractivity.dto.UserActivityDto;
 import com.codeit.team2.monew.module.domain.useractivity.repository.MongoUserActivityRepository;
-import jakarta.annotation.PostConstruct;
-import java.time.Instant;
 import java.util.Collections;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -23,14 +22,13 @@ public class MongoUserActivityService implements UserActivityService {
         return null;
     }
 
-    @PostConstruct
-    void init() {
+    public void createUserActivity(User user) {
         userActivityRepository.save(
             new UserActivity(
-                UUID.randomUUID(),
-                "email",
-                "nickname",
-                Instant.now(),
+                user.getId(),
+                user.getEmail(),
+                user.getNickname(),
+                user.getCreatedAt(),
                 Collections.emptyList(),
                 Collections.emptyList(),
                 Collections.emptyList(),

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/service/MongoUserActivityService.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/service/MongoUserActivityService.java
@@ -1,0 +1,41 @@
+package com.codeit.team2.monew.module.domain.useractivity.service;
+
+import com.codeit.team2.monew.module.domain.useractivity.document.UserActivity;
+import com.codeit.team2.monew.module.domain.useractivity.dto.UserActivityDto;
+import com.codeit.team2.monew.module.domain.useractivity.repository.MongoUserActivityRepository;
+import jakarta.annotation.PostConstruct;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.db-type", havingValue = "mongodb")
+public class MongoUserActivityService implements UserActivityService {
+
+    private final MongoUserActivityRepository userActivityRepository;
+
+    @Override
+    public UserActivityDto findUserActivities(UUID loginId, UUID userId) {
+        return null;
+    }
+
+    @PostConstruct
+    void init() {
+        userActivityRepository.save(
+            new UserActivity(
+                UUID.randomUUID(),
+                "email",
+                "nickname",
+                Instant.now(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList()
+            )
+        );
+    }
+}

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/service/UserActivityServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/service/UserActivityServiceImpl.java
@@ -71,19 +71,7 @@ public class UserActivityServiceImpl implements UserActivityService {
         List<ArticleView> articleViews =
             articleViewRepository.findTop10ByUserOrderByViewedAtDesc(user);
         List<ArticleViewItemDto> articleViewItemDtos = articleViews.stream().map(
-            articleView -> new ArticleViewItemDto(
-                articleView.getId(),
-                articleView.getUser().getId(),
-                articleView.getCreatedAt(),
-                articleView.getArticle().getId(),
-                articleView.getArticle().getSource(),
-                articleView.getArticle().getSourceUrl(),
-                articleView.getArticle().getTitle(),
-                articleView.getArticle().getPublishedDate(),
-                articleView.getArticle().getSummary(),
-                commentRepository.countByArticle(articleView.getArticle()),
-                articleView.getArticle().getViewCount().longValue()
-            )
+            articleView -> userActivityMapper.toArticleViewItemDto(articleView, commentRepository)
         ).toList();
 
         return userActivityMapper.toUserActivityDto(

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/service/UserActivityServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/service/UserActivityServiceImpl.java
@@ -19,11 +19,14 @@ import com.codeit.team2.monew.module.domain.useractivity.mapper.UserActivityMapp
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+//@Primary
 @Service
 @RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.db-type", havingValue = "postgresql")
 public class UserActivityServiceImpl implements UserActivityService {
 
     private final UserRepository userRepository;

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/service/UserActivityServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/service/UserActivityServiceImpl.java
@@ -23,7 +23,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-//@Primary
 @Service
 @RequiredArgsConstructor
 @ConditionalOnProperty(name = "app.db-type", havingValue = "postgresql")

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/service/UserActivityServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/service/UserActivityServiceImpl.java
@@ -10,10 +10,10 @@ import com.codeit.team2.monew.module.domain.subscription.entity.Subscription;
 import com.codeit.team2.monew.module.domain.subscription.repository.SubscriptionRepository;
 import com.codeit.team2.monew.module.domain.user.entity.User;
 import com.codeit.team2.monew.module.domain.user.repository.UserRepository;
-import com.codeit.team2.monew.module.domain.useractivity.dto.ArticleViewItem;
-import com.codeit.team2.monew.module.domain.useractivity.dto.CommentItem;
-import com.codeit.team2.monew.module.domain.useractivity.dto.CommentLikeItem;
-import com.codeit.team2.monew.module.domain.useractivity.dto.SubscriptionItem;
+import com.codeit.team2.monew.module.domain.useractivity.dto.ArticleViewItemDto;
+import com.codeit.team2.monew.module.domain.useractivity.dto.CommentItemDto;
+import com.codeit.team2.monew.module.domain.useractivity.dto.CommentLikeItemDto;
+import com.codeit.team2.monew.module.domain.useractivity.dto.SubscriptionItemDto;
 import com.codeit.team2.monew.module.domain.useractivity.dto.UserActivityDto;
 import com.codeit.team2.monew.module.domain.useractivity.mapper.UserActivityMapper;
 import java.util.List;
@@ -47,28 +47,28 @@ public class UserActivityServiceImpl implements UserActivityService {
         // 구독 중인 관심사
         List<Subscription> subscriptions =
             subscriptionRepository.findAllByUserOrderByCreatedAtDesc(user);
-        List<SubscriptionItem> subscriptionItems = subscriptions.stream().map(
+        List<SubscriptionItemDto> subscriptionItemDtos = subscriptions.stream().map(
             userActivityMapper::toSubscriptionItem
         ).toList();
 
         // 최근 작성한 댓글
         List<Comment> comments = commentRepository.findTop10ByUserOrderByCreatedAtDesc(user);
-        List<CommentItem> commentItems = comments.stream().map(
+        List<CommentItemDto> commentItemDtos = comments.stream().map(
             comment -> userActivityMapper.toCommentItem(user, comment)
         ).toList();
 
         // 최근 좋아요 누른 댓글
         List<CommentLike> commentLikes =
             commentLikeRepository.findTop10ByUserOrderByLikedAtDesc(user);
-        List<CommentLikeItem> commentLikeItems = commentLikes.stream().map(
+        List<CommentLikeItemDto> commentLikeItemDtos = commentLikes.stream().map(
             userActivityMapper::toCommentLikeItem
         ).toList();
 
         // 최근 본 뉴스
         List<ArticleView> articleViews =
             articleViewRepository.findTop10ByUserOrderByViewedAtDesc(user);
-        List<ArticleViewItem> articleViewItems = articleViews.stream().map(
-            articleView -> new ArticleViewItem(
+        List<ArticleViewItemDto> articleViewItemDtos = articleViews.stream().map(
+            articleView -> new ArticleViewItemDto(
                 articleView.getId(),
                 articleView.getUser().getId(),
                 articleView.getCreatedAt(),
@@ -85,10 +85,10 @@ public class UserActivityServiceImpl implements UserActivityService {
 
         return userActivityMapper.toUserActivityDto(
             user,
-            subscriptionItems,
-            commentItems,
-            commentLikeItems,
-            articleViewItems
+            subscriptionItemDtos,
+            commentItemDtos,
+            commentLikeItemDtos,
+            articleViewItemDtos
         );
     }
 }

--- a/monew/src/main/resources/application-dev.yaml
+++ b/monew/src/main/resources/application-dev.yaml
@@ -13,5 +13,4 @@ spring:
       mode: always
   data:
     mongodb:
-      #      uri: mongodb+srv://${MONGO_USERNAME}:${MONGO_PASSWORD}@${MONGO_HOST}/${MONGO_DB}?retryWrites=true&w=majority
       uri: mongodb://localhost:27017/monew

--- a/monew/src/main/resources/application-dev.yaml
+++ b/monew/src/main/resources/application-dev.yaml
@@ -13,4 +13,5 @@ spring:
       mode: always
   data:
     mongodb:
-      uri: mongodb+srv://${MONGO_USERNAME}:${MONGO_PASSWORD}@${MONGO_HOST}/${MONGO_DB}?retryWrites=true&w=majority
+      #      uri: mongodb+srv://${MONGO_USERNAME}:${MONGO_PASSWORD}@${MONGO_HOST}/${MONGO_DB}?retryWrites=true&w=majority
+      uri: mongodb://localhost:27017/monew

--- a/monew/src/main/resources/application-dev.yaml
+++ b/monew/src/main/resources/application-dev.yaml
@@ -11,3 +11,6 @@ spring:
   sql:
     init:
       mode: always
+  data:
+    mongodb:
+      uri: mongodb+srv://${MONGO_USERNAME}:${MONGO_PASSWORD}@${MONGO_HOST}/${MONGO_DB}?retryWrites=true&w=majority

--- a/monew/src/main/resources/application.yaml
+++ b/monew/src/main/resources/application.yaml
@@ -40,4 +40,4 @@ news:
     client-secret: ${NAVER_CLIENT_SECRET}
 
 app:
-  db-type: mongodb  # postgresql || mongodb
+  db-type: postgresql  # postgresql || mongodb

--- a/monew/src/main/resources/application.yaml
+++ b/monew/src/main/resources/application.yaml
@@ -39,3 +39,5 @@ news:
     client-id: ${NAVER_CLIENT_ID}
     client-secret: ${NAVER_CLIENT_SECRET}
 
+app:
+  db-type: mongodb  # postgresql || mongodb

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/user/service/UserServiceImplTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/user/service/UserServiceImplTest.java
@@ -24,6 +24,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceImplTest {
@@ -33,6 +34,9 @@ class UserServiceImplTest {
 
     @Spy
     private UserMapper userMapper = Mappers.getMapper(UserMapper.class);
+
+    @Spy
+    private ApplicationEventPublisher applicationEventPublisher;
 
     @InjectMocks
     private UserServiceImpl userService;

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/useractivity/service/MongoUserActivityServiceTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/useractivity/service/MongoUserActivityServiceTest.java
@@ -1,16 +1,27 @@
 package com.codeit.team2.monew.module.domain.useractivity.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.codeit.team2.monew.module.domain.user.entity.User;
 import com.codeit.team2.monew.module.domain.useractivity.document.UserActivity;
+import com.codeit.team2.monew.module.domain.useractivity.dto.UserActivityDto;
+import com.codeit.team2.monew.module.domain.useractivity.mapper.UserActivityMapper;
 import com.codeit.team2.monew.module.domain.useractivity.repository.MongoUserActivityRepository;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -19,8 +30,50 @@ class MongoUserActivityServiceTest {
     @Mock
     private MongoUserActivityRepository userActivityRepository;
 
+    @Spy
+    private UserActivityMapper userActivitiesMapper = Mappers.getMapper(
+        UserActivityMapper.class);
+
     @InjectMocks
     private MongoUserActivityService userActivityService;
+
+    @Nested
+    class findUserActivitiesTest {
+
+        @Test
+        void 활동_내역_관리_조회_성공() {
+            // given
+            UUID userId = UUID.randomUUID();
+            UUID loginId = userId;
+
+            String email = "email";
+            String nickname = "nickname";
+            Instant createdAt = Instant.now();
+
+            UserActivity userActivity = new UserActivity(
+                userId,
+                email,
+                nickname,
+                createdAt,
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList()
+            );
+
+            when(userActivityRepository.findById(userId)).thenReturn(Optional.of(userActivity));
+
+            // when
+            UserActivityDto userActivityDto =
+                userActivityService.findUserActivities(loginId, userId);
+
+            // then
+            assertEquals(userId, userActivityDto.id());
+            assertEquals(email, userActivityDto.email());
+            assertEquals(nickname, userActivityDto.nickname());
+            assertEquals(createdAt, userActivityDto.createdAt());
+        }
+    }
 
     @Test
     void 사용자_활동_내역_초기_생성_성공() {

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/useractivity/service/MongoUserActivityServiceTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/useractivity/service/MongoUserActivityServiceTest.java
@@ -2,6 +2,7 @@ package com.codeit.team2.monew.module.domain.useractivity.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -72,6 +73,18 @@ class MongoUserActivityServiceTest {
             assertEquals(email, userActivityDto.email());
             assertEquals(nickname, userActivityDto.nickname());
             assertEquals(createdAt, userActivityDto.createdAt());
+        }
+
+        @Test
+        void 본인_검증_예외() {
+            // given
+            UUID userId = UUID.randomUUID();
+            UUID loginId = UUID.randomUUID();
+
+            // when & then
+            assertThrows(Exception.class, () -> {
+                userActivityService.findUserActivities(loginId, userId);
+            });
         }
     }
 

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/useractivity/service/MongoUserActivityServiceTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/useractivity/service/MongoUserActivityServiceTest.java
@@ -1,0 +1,50 @@
+package com.codeit.team2.monew.module.domain.useractivity.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import com.codeit.team2.monew.module.domain.user.entity.User;
+import com.codeit.team2.monew.module.domain.useractivity.document.UserActivity;
+import com.codeit.team2.monew.module.domain.useractivity.repository.MongoUserActivityRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MongoUserActivityServiceTest {
+
+    @Mock
+    private MongoUserActivityRepository userActivityRepository;
+
+    @InjectMocks
+    private MongoUserActivityService userActivityService;
+
+    @Test
+    void 사용자_활동_내역_초기_생성_성공() {
+        // given
+        String email = "email";
+        String nickname = "nickname";
+        String password = "password";
+
+        User user = new User(email, nickname, password, false);
+
+        // when
+        userActivityService.createUserActivity(user);
+
+        // then
+        ArgumentCaptor<UserActivity> captor = ArgumentCaptor.forClass(UserActivity.class);
+        verify(userActivityRepository).save(captor.capture());
+
+        UserActivity saved = captor.getValue();
+        assertThat(saved.getEmail()).isEqualTo(email);
+        assertThat(saved.getNickname()).isEqualTo(nickname);
+        assertThat(saved.getSubscriptions()).isEmpty();
+        assertThat(saved.getComments()).isEmpty();
+        assertThat(saved.getCommentLikes()).isEmpty();
+        assertThat(saved.getArticleViews()).isEmpty();
+    }
+
+}


### PR DESCRIPTION
## 구현 내용
<!-- 구현한 기능에 대한 간략한 설명을 작성해주세요 -->
- MongoDB 연동
- 사용자 관리 Document 정의
- 사용자 생성 시 이벤트 기반으로 UserActivity 생성

### 구현된 API 엔드포인트
<!-- 구현한 API 엔드포인트 목록을 작성해주세요 -->
<!-- 예시:
- GET /api/employees - 직원 목록 조회
- POST /api/employees - 직원 등록
- GET /api/employees/{id} - 직원 상세 조회
- PATCH /api/employees/{id} - 직원 정보 수정
- DELETE /api/employees/{id} - 직원 삭제
- GET /api/employees/stats/trend - 직원 수 추이 조회
- GET /api/employees/stats/distribution - 직원 분포 조회
- GET /api/employees/count - 직원 수 조회 -->


### 주요 변경사항
<!-- 주요 변경사항을 작성해주세요 -->
- application.yml의 app.db-type 의 값을 통해 postgresql, mongodb 버전을 선택할 수 있습니다.(기본값: postgresql)
- fetch join을 도입하여 N+1 문제 해결
- ArticleViewItemDto 변환 UserActivityMapper에 추가

## 테스트 완료 사항
<!-- 테스트한 항목에 체크(x)해주세요 -->
- [x] 단위 테스트
- [ ] 통합 테스트
- [x] API 테스트 (Swagger/Postman 등)
- [ ] 기타 테스트

## 스크린샷
<!-- 필요한 경우 관련 스크린샷을 첨부해주세요 -->

## 체크리스트
<!-- 제출 전 확인해야 할 사항들입니다 -->
- [x] 코딩, 커밋 컨벤션 준수
- [ ] 모든 테스트 통과
- [ ] API 명세 준수
- [ ] 불필요한 로그, 주석, 미사용 코드 제거

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #81 

## 추가 코멘트 (선택)
<!-- 리뷰어에게 전달할 추가 정보가 있다면 작성해주세요 -->
아직 mongodb로의 전환이 완전히 이루어지지 않았습니다.
applicaition.yml에 기재된 옵션을 그대로 두시면 문제없이 동작합니다.
```
app:
  db-type: postgresql  # postgresql || mongodb
```
