### PR TITLE
Feat/#87/article read

### DIFF
--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/controller/ArticleController.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/controller/ArticleController.java
@@ -2,12 +2,17 @@ package com.codeit.team2.monew.module.domain.article.controller;
 
 
 import com.codeit.team2.monew.module.domain.article.dto.ArticleViewDto;
+import com.codeit.team2.monew.module.domain.article.dto.CursorPageResponseArticleDto;
+import com.codeit.team2.monew.module.domain.article.dto.request.ArticleFindRequest;
 import com.codeit.team2.monew.module.domain.article.service.ArticleService;
+import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -40,6 +45,13 @@ public class ArticleController {
     public ResponseEntity<?> hardDeleteArticle(@PathVariable UUID articleId) {
         articleService.hardDelete(articleId);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("")
+    public ResponseEntity<CursorPageResponseArticleDto> findAll(
+        @RequestHeader("MoNew-Request-User-ID") UUID userId,
+        @Valid @ModelAttribute ArticleFindRequest articleFindRequest) {
+        return ResponseEntity.ok().body(articleService.findAll(userId, articleFindRequest));
     }
 
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/controller/ArticleController.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/controller/ArticleController.java
@@ -51,7 +51,10 @@ public class ArticleController {
     public ResponseEntity<CursorPageResponseArticleDto> findAll(
         @RequestHeader("MoNew-Request-User-ID") UUID userId,
         @Valid @ModelAttribute ArticleFindRequest articleFindRequest) {
-        return ResponseEntity.ok().body(articleService.findAll(userId, articleFindRequest));
+        log.info("Start - ArticleController/findAll");
+        CursorPageResponseArticleDto result = articleService.findAll(userId, articleFindRequest);
+        log.info("Complete - ArticleController/findAll");
+        return ResponseEntity.ok().body(result);
     }
 
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/dto/ArticleDto.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/dto/ArticleDto.java
@@ -8,10 +8,10 @@ public record ArticleDto(
     String source,
     String sourceUrl,
     String title,
-    Instant publishedDate,
+    Instant publishDate,
     String summary,
-    Integer commentCount,
-    Integer viewCount,
+    Long commentCount,
+    Long viewCount,
     Boolean viewedByMe
 ) {
 

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/dto/CursorPageResponseArticleDto.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/dto/CursorPageResponseArticleDto.java
@@ -1,0 +1,15 @@
+package com.codeit.team2.monew.module.domain.article.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+public record CursorPageResponseArticleDto(
+    List<ArticleDto> content,
+    Object nextCursor,  // publishDate, commentCount, viewCount
+    Instant nextAfter,  // createdAt 기준
+    int size,
+    long totalElements,
+    boolean hasNext
+) {
+
+}

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/dto/request/ArticleFindRequest.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/dto/request/ArticleFindRequest.java
@@ -1,0 +1,34 @@
+package com.codeit.team2.monew.module.domain.article.dto.request;
+
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.domain.Sort.Direction;
+
+public record ArticleFindRequest(
+    @Nullable
+    String keyword,
+    @Nullable
+    UUID interestId,
+    @Nullable
+    List<ArticleSourceIn> sourceIn,
+    @Nullable
+    Instant publishDateFrom,
+    @Nullable
+    Instant publishDateTo,
+    @NotNull(message = "정렬 속성을 지정하세요.")
+    ArticleOrderBy orderBy,
+    @NotNull(message = "정렬 방향을 지정하세요.")
+    Direction direction,
+    @Nullable
+    String cursor,
+    @Nullable
+    Instant after,
+    @NotNull(message = "커서 페이지 크기를 지정하세요.")
+    int limit
+
+) {
+
+}

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/dto/request/ArticleOrderBy.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/dto/request/ArticleOrderBy.java
@@ -1,0 +1,7 @@
+package com.codeit.team2.monew.module.domain.article.dto.request;
+
+public enum ArticleOrderBy {
+    publishDate,
+    commentCount,
+    viewCount
+}

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/dto/request/ArticleSourceIn.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/dto/request/ArticleSourceIn.java
@@ -1,0 +1,5 @@
+package com.codeit.team2.monew.module.domain.article.dto.request;
+
+public enum ArticleSourceIn {
+    NAVER
+}

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/repository/ArticleCustomRepository.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/repository/ArticleCustomRepository.java
@@ -5,13 +5,13 @@ import com.codeit.team2.monew.module.domain.article.entity.Article;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort.Direction;
 
 public interface ArticleCustomRepository {
 
-    Page<Article> findByPublishDate(
+    Slice<Article> findByPublishDate(
         String keyword,
         UUID interestId,
         List<ArticleSourceIn> sourceIn,
@@ -23,7 +23,7 @@ public interface ArticleCustomRepository {
         Pageable pageable
     );
 
-    Page<Article> findByViewCount(
+    Slice<Article> findByViewCount(
         String keyword,
         UUID interestId,
         List<ArticleSourceIn> sourceIn,
@@ -35,7 +35,7 @@ public interface ArticleCustomRepository {
         Pageable pageable
     );
 
-    Page<Article> findByCommentCount(
+    Slice<Article> findByCommentCount(
         String keyword,
         UUID interestId,
         List<ArticleSourceIn> sourceIn,

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/repository/ArticleCustomRepository.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/repository/ArticleCustomRepository.java
@@ -1,0 +1,52 @@
+package com.codeit.team2.monew.module.domain.article.repository;
+
+import com.codeit.team2.monew.module.domain.article.dto.request.ArticleSourceIn;
+import com.codeit.team2.monew.module.domain.article.entity.Article;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+
+public interface ArticleCustomRepository {
+
+    Page<Article> findByPublishDate(
+        String keyword,
+        UUID interestId,
+        List<ArticleSourceIn> sourceIn,
+        Instant publishDateFrom,
+        Instant publishDateTo,
+        Direction direction,
+        String cursor,
+        Instant after,
+        Pageable pageable
+    );
+
+    Page<Article> findByViewCount(
+        String keyword,
+        UUID interestId,
+        List<ArticleSourceIn> sourceIn,
+        Instant publishDateFrom,
+        Instant publishDateTo,
+        Direction direction,
+        String cursor,
+        Instant after,
+        Pageable pageable
+    );
+
+    Page<Article> findByCommentCount(
+        String keyword,
+        UUID interestId,
+        List<ArticleSourceIn> sourceIn,
+        Instant publishDateFrom,
+        Instant publishDateTo,
+        Direction direction,
+        String cursor,
+        Instant after,
+        Pageable pageable
+    );
+
+    long countFilteredTotalElements(String keyword, UUID interestId,
+        List<ArticleSourceIn> sourceIn, Instant publishDateFrom, Instant publishDateTo);
+}

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/repository/ArticleCustomRepositoryImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/repository/ArticleCustomRepositoryImpl.java
@@ -114,14 +114,6 @@ public class ArticleCustomRepositoryImpl implements ArticleCustomRepository {
             new OrderSpecifier<>(order, article.publishedDate),
             new OrderSpecifier<>(order, article.createdAt));
 
-        // totalElements: 전체 데이터 중 where 조건을 만족하는 데이터 수
-//        long totalElements = queryFactory
-//            .selectFrom(article)
-//            .where(where)
-//            .fetchCount();
-        long totalElements = countFilteredTotalElements(keyword, interestId, sourceIn,
-            publishDateFrom, publishDateTo);
-
         List<Article> result = query.limit(pageable.getPageSize() + 1).fetch();
 
         boolean hasNext = result.size() > pageable.getPageSize();
@@ -136,7 +128,47 @@ public class ArticleCustomRepositoryImpl implements ArticleCustomRepository {
     public Slice<Article> findByViewCount(String keyword, UUID interestId,
         List<ArticleSourceIn> sourceIn, Instant publishDateFrom, Instant publishDateTo,
         Direction direction, String cursor, Instant after, Pageable pageable) {
-        return null;
+        QArticle article = QArticle.article;
+        QArticleInterest articleInterest = QArticleInterest.articleInterest;
+
+        JPAQuery<Article> query = queryFactory.selectFrom(article).distinct();
+
+        BooleanBuilder where = buildCommonFilters(article, articleInterest,
+            keyword, interestId, sourceIn, publishDateFrom, publishDateTo, query);
+
+        // 커서 조건 확인: 커서 없으면 생략
+        if (cursor != null && after != null) {
+            // Object -> Long
+            Long viewCountCursor = Long.parseLong(cursor);
+            // ASC
+            if (direction.isAscending()) {
+                where.and(article.viewCount.gt(viewCountCursor))
+                    .or(article.viewCount.eq(viewCountCursor)
+                        .and(article.createdAt.gt(after)));
+            } else {
+                //DESC
+                where.and(article.viewCount.lt(viewCountCursor))
+                    .or(article.viewCount.eq(viewCountCursor)
+                        .and(article.createdAt.lt(after)));
+            }
+        }
+
+        query.where(where);
+
+        // 정렬 조건: publishedDate + createdAt
+        Order order = direction.isAscending() ? Order.ASC : Order.DESC;
+        query.orderBy(
+            new OrderSpecifier<>(order, article.viewCount),
+            new OrderSpecifier<>(order, article.createdAt));
+
+        List<Article> result = query.limit(pageable.getPageSize() + 1).fetch();
+
+        boolean hasNext = result.size() > pageable.getPageSize();
+        if (hasNext) {
+            result.remove(pageable.getPageSize());
+        }
+
+        return new SliceImpl<>(result, pageable, hasNext);
     }
 
     @Override

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/repository/ArticleCustomRepositoryImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/repository/ArticleCustomRepositoryImpl.java
@@ -1,0 +1,146 @@
+package com.codeit.team2.monew.module.domain.article.repository;
+
+import com.codeit.team2.monew.module.domain.article.dto.request.ArticleSourceIn;
+import com.codeit.team2.monew.module.domain.article.entity.Article;
+import com.codeit.team2.monew.module.domain.article.entity.QArticle;
+import com.codeit.team2.monew.module.domain.relation.entity.QArticleInterest;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ArticleCustomRepositoryImpl implements ArticleCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    private BooleanBuilder buildCommonFilters(QArticle article, QArticleInterest articleInterest,
+        String keyword, UUID interestId, List<ArticleSourceIn> sourceIn,
+        Instant publishDateFrom, Instant publishDateTo, JPAQuery<Article> query) {
+
+        BooleanBuilder where = new BooleanBuilder();
+
+        // 삭제되지 않은 기사만
+        where.and(article.deleted.isFalse());
+
+        // keyword가 제목, 요약과 부분일치하는 경우
+        if (keyword != null && !keyword.isBlank()) {
+            where.and(article.title.contains(keyword)
+                .or(article.summary.contains(keyword)));
+        }
+
+        // 관심사 필터링(ArticleInterest와 join 필요)
+        if (interestId != null) {
+            query.leftJoin(article.articleInterests, articleInterest);
+            where.and(articleInterest.interest.id.eq(interestId));
+        }
+
+        // 출처 필터링
+        if (sourceIn != null && !sourceIn.isEmpty()) {
+            List<String> sources = sourceIn.stream().map(Enum::name).toList();
+            where.and(article.source.in(sources));
+        }
+
+        // 날짜 범위 필터링
+        if (publishDateFrom != null) {
+            where.and(article.publishedDate.goe(publishDateFrom));
+        }
+        if (publishDateTo != null) {
+            where.and(article.publishedDate.loe(publishDateTo));
+        }
+
+        return where;
+    }
+
+    @Override
+    public long countFilteredTotalElements(String keyword, UUID interestId,
+        List<ArticleSourceIn> sourceIn, Instant publishDateFrom, Instant publishDateTo) {
+        QArticle article = QArticle.article;
+        QArticleInterest articleInterest = QArticleInterest.articleInterest;
+
+        JPAQuery<Article> query = queryFactory.selectFrom(article);
+        BooleanBuilder where = buildCommonFilters(article, articleInterest,
+            keyword, interestId, sourceIn, publishDateFrom, publishDateTo, query);
+
+        return query.where(where).fetchCount();
+    }
+
+    @Override
+    public Page<Article> findByPublishDate(String keyword, UUID interestId,
+        List<ArticleSourceIn> sourceIn, Instant publishDateFrom, Instant publishDateTo,
+        Direction direction, String cursor, Instant after, Pageable pageable) {
+
+        QArticle article = QArticle.article;
+        QArticleInterest articleInterest = QArticleInterest.articleInterest;
+
+        JPAQuery<Article> query = queryFactory.selectFrom(article).distinct();
+
+        BooleanBuilder where = buildCommonFilters(article, articleInterest,
+            keyword, interestId, sourceIn, publishDateFrom, publishDateTo, query);
+
+        // 커서 조건 확인: 커서 없으면 생략
+        if (cursor != null && after != null) {
+            // Object -> Instant
+            Instant publishDateCursor = Instant.parse(cursor);
+            // ASC
+            if (direction.isAscending()) {
+                where.and(article.publishedDate.gt(publishDateCursor))
+                    .or(article.publishedDate.eq(publishDateCursor)
+                        .and(article.createdAt.gt(after)));
+            } else {
+                //DESC
+                where.and(article.publishedDate.lt(publishDateCursor))
+                    .or(article.publishedDate.eq(publishDateCursor)
+                        .and(article.createdAt.lt(after)));
+            }
+        }
+
+        query.where(where);
+
+        // 정렬 조건: publishedDate + createdAt
+        Order order = direction.isAscending() ? Order.ASC : Order.DESC;
+        query.orderBy(
+            new OrderSpecifier<>(order, article.publishedDate),
+            new OrderSpecifier<>(order, article.createdAt));
+
+        // totalElements: 전체 데이터 중 where 조건을 만족하는 데이터 수
+        long totalElements = queryFactory
+            .selectFrom(article)
+            .where(where)
+            .fetchCount();
+
+        List<Article> result = query.limit(pageable.getPageSize() + 1).fetch();
+
+        boolean hasNext = result.size() > pageable.getPageSize();
+        if (hasNext) {
+            result.remove(pageable.getPageSize());
+        }
+
+        return new PageImpl<>(result, pageable, totalElements);
+    }
+
+    @Override
+    public Page<Article> findByViewCount(String keyword, UUID interestId,
+        List<ArticleSourceIn> sourceIn, Instant publishDateFrom, Instant publishDateTo,
+        Direction direction, String cursor, Instant after, Pageable pageable) {
+        return null;
+    }
+
+    @Override
+    public Page<Article> findByCommentCount(String keyword, UUID interestId,
+        List<ArticleSourceIn> sourceIn, Instant publishDateFrom, Instant publishDateTo,
+        Direction direction, String cursor, Instant after, Pageable pageable) {
+        return null;
+    }
+}

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/repository/ArticleCustomRepositoryImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/repository/ArticleCustomRepositoryImpl.java
@@ -13,9 +13,9 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Repository;
 
@@ -77,7 +77,7 @@ public class ArticleCustomRepositoryImpl implements ArticleCustomRepository {
     }
 
     @Override
-    public Page<Article> findByPublishDate(String keyword, UUID interestId,
+    public Slice<Article> findByPublishDate(String keyword, UUID interestId,
         List<ArticleSourceIn> sourceIn, Instant publishDateFrom, Instant publishDateTo,
         Direction direction, String cursor, Instant after, Pageable pageable) {
 
@@ -115,10 +115,12 @@ public class ArticleCustomRepositoryImpl implements ArticleCustomRepository {
             new OrderSpecifier<>(order, article.createdAt));
 
         // totalElements: 전체 데이터 중 where 조건을 만족하는 데이터 수
-        long totalElements = queryFactory
-            .selectFrom(article)
-            .where(where)
-            .fetchCount();
+//        long totalElements = queryFactory
+//            .selectFrom(article)
+//            .where(where)
+//            .fetchCount();
+        long totalElements = countFilteredTotalElements(keyword, interestId, sourceIn,
+            publishDateFrom, publishDateTo);
 
         List<Article> result = query.limit(pageable.getPageSize() + 1).fetch();
 
@@ -127,18 +129,18 @@ public class ArticleCustomRepositoryImpl implements ArticleCustomRepository {
             result.remove(pageable.getPageSize());
         }
 
-        return new PageImpl<>(result, pageable, totalElements);
+        return new SliceImpl<>(result, pageable, hasNext);
     }
 
     @Override
-    public Page<Article> findByViewCount(String keyword, UUID interestId,
+    public Slice<Article> findByViewCount(String keyword, UUID interestId,
         List<ArticleSourceIn> sourceIn, Instant publishDateFrom, Instant publishDateTo,
         Direction direction, String cursor, Instant after, Pageable pageable) {
         return null;
     }
 
     @Override
-    public Page<Article> findByCommentCount(String keyword, UUID interestId,
+    public Slice<Article> findByCommentCount(String keyword, UUID interestId,
         List<ArticleSourceIn> sourceIn, Instant publishDateFrom, Instant publishDateTo,
         Direction direction, String cursor, Instant after, Pageable pageable) {
         return null;

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/repository/ArticleCustomRepositoryImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/repository/ArticleCustomRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.codeit.team2.monew.module.domain.article.repository;
 import com.codeit.team2.monew.module.domain.article.dto.request.ArticleSourceIn;
 import com.codeit.team2.monew.module.domain.article.entity.Article;
 import com.codeit.team2.monew.module.domain.article.entity.QArticle;
+import com.codeit.team2.monew.module.domain.comment.entity.QComment;
 import com.codeit.team2.monew.module.domain.relation.entity.QArticleInterest;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Order;
@@ -175,6 +176,49 @@ public class ArticleCustomRepositoryImpl implements ArticleCustomRepository {
     public Slice<Article> findByCommentCount(String keyword, UUID interestId,
         List<ArticleSourceIn> sourceIn, Instant publishDateFrom, Instant publishDateTo,
         Direction direction, String cursor, Instant after, Pageable pageable) {
-        return null;
+        QArticle article = QArticle.article;
+        QArticleInterest articleInterest = QArticleInterest.articleInterest;
+        QComment comment = QComment.comment;
+
+        JPAQuery<Article> query = queryFactory
+            .select(article)
+            .from(article)
+            .leftJoin(article.articleInterests, articleInterest)
+            .leftJoin(comment).on(comment.article.eq(article))
+            .groupBy(article.id);
+
+        BooleanBuilder where = buildCommonFilters(article, articleInterest,
+            keyword, interestId, sourceIn, publishDateFrom, publishDateTo, query);
+
+        if (cursor != null && after != null) {
+            Long commentCursor = Long.parseLong(cursor);
+            if (direction.isAscending()) {
+                query.having(comment.count().gt(commentCursor)
+                    .or(comment.count().eq(commentCursor).and(article.createdAt.gt(after))));
+            } else {
+                query.having(comment.count().lt(commentCursor)
+                    .or(comment.count().eq(commentCursor).and(article.createdAt.lt(after))));
+            }
+        }
+
+        query.where(where);
+
+        Order order = direction.isAscending() ? Order.ASC : Order.DESC;
+        query.orderBy(
+            new OrderSpecifier<>(order, comment.count()),
+            // commentCount 기준으로 세야함 -> 쿼리에서 left join으로 가져온 comment의 수
+            new OrderSpecifier<>(order, article.createdAt)
+        );
+
+        List<Article> articles = query
+            .limit(pageable.getPageSize() + 1)
+            .fetch();
+
+        boolean hasNext = articles.size() > pageable.getPageSize();
+        if (hasNext) {
+            articles.remove(pageable.getPageSize());
+        }
+
+        return new SliceImpl<>(articles, pageable, hasNext);
     }
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/repository/ArticleViewRepository.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/repository/ArticleViewRepository.java
@@ -15,4 +15,6 @@ public interface ArticleViewRepository extends JpaRepository<ArticleView, UUID> 
 
     @EntityGraph(attributePaths = {"article", "user"})
     List<ArticleView> findTop10ByUserOrderByViewedAtDesc(User user);
+
+    boolean existsByUserIdAndArticleId(UUID userId, UUID articleId);
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/service/ArticleService.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/service/ArticleService.java
@@ -1,6 +1,8 @@
 package com.codeit.team2.monew.module.domain.article.service;
 
 import com.codeit.team2.monew.module.domain.article.dto.ArticleViewDto;
+import com.codeit.team2.monew.module.domain.article.dto.CursorPageResponseArticleDto;
+import com.codeit.team2.monew.module.domain.article.dto.request.ArticleFindRequest;
 import java.util.UUID;
 
 public interface ArticleService {
@@ -10,4 +12,6 @@ public interface ArticleService {
     void softDelete(UUID articleId);
 
     void hardDelete(UUID articleId);
+
+    CursorPageResponseArticleDto findAll(UUID userId, ArticleFindRequest articleFindRequest);
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/service/ArticleServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/service/ArticleServiceImpl.java
@@ -1,17 +1,29 @@
 package com.codeit.team2.monew.module.domain.article.service;
 
+import com.codeit.team2.monew.module.domain.article.dto.ArticleDto;
 import com.codeit.team2.monew.module.domain.article.dto.ArticleViewDto;
+import com.codeit.team2.monew.module.domain.article.dto.CursorPageResponseArticleDto;
+import com.codeit.team2.monew.module.domain.article.dto.request.ArticleFindRequest;
+import com.codeit.team2.monew.module.domain.article.dto.request.ArticleOrderBy;
 import com.codeit.team2.monew.module.domain.article.entity.Article;
 import com.codeit.team2.monew.module.domain.article.entity.ArticleView;
 import com.codeit.team2.monew.module.domain.article.mapper.ArticleMapper;
+import com.codeit.team2.monew.module.domain.article.repository.ArticleCustomRepository;
 import com.codeit.team2.monew.module.domain.article.repository.ArticleRepository;
 import com.codeit.team2.monew.module.domain.article.repository.ArticleViewRepository;
+import com.codeit.team2.monew.module.domain.comment.repository.CommentRepository;
 import com.codeit.team2.monew.module.domain.user.entity.User;
 import com.codeit.team2.monew.module.domain.user.repository.UserRepository;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 
@@ -24,6 +36,8 @@ public class ArticleServiceImpl implements ArticleService {
     private final ArticleViewRepository articleViewRepository;
     private final UserRepository userRepository;
     private final ArticleMapper articleMapper;
+    private final ArticleCustomRepository articleCustomRepository;
+    private final CommentRepository commentRepository;
 
     @Override
     public ArticleViewDto createUserArticleView(UUID userId, UUID articleId) {
@@ -71,4 +85,62 @@ public class ArticleServiceImpl implements ArticleService {
         return optionalArticle;
     }
 
+    @Override
+    public CursorPageResponseArticleDto findAll(UUID userId,
+        ArticleFindRequest articleFindRequest) {
+        Page<Article> pages;
+        Pageable pageable = PageRequest.of(0, articleFindRequest.limit(), Sort.unsorted());
+        if (articleFindRequest.orderBy().equals(ArticleOrderBy.publishDate)) {
+            pages = articleCustomRepository.findByPublishDate(articleFindRequest.keyword(),
+                articleFindRequest.interestId(),
+                articleFindRequest.sourceIn(),
+                articleFindRequest.publishDateFrom(),
+                articleFindRequest.publishDateTo(),
+                articleFindRequest.direction(),
+                articleFindRequest.cursor(),
+                articleFindRequest.after(),
+                pageable);
+        } else {
+            pages = null;
+        }
+
+        List<Article> articles = pages.getContent();
+        List<ArticleDto> articleDtos = new ArrayList<>();
+        articles.stream().forEach(article -> {
+            Long commentCount = commentRepository.countByArticle(article);
+            boolean viewedByMe = articleViewRepository.existsByUserIdAndArticleId(userId,
+                article.getId());
+            articleDtos.add(new ArticleDto(article.getId(),
+                article.getSource(),
+                article.getSourceUrl(),
+                article.getTitle(),
+                article.getPublishedDate(),
+                article.getSummary(),
+                commentCount,
+                article.getViewCount(),
+                viewedByMe));
+        });
+
+        long totalElements = articleCustomRepository.countFilteredTotalElements(
+            articleFindRequest.keyword(), articleFindRequest.interestId(),
+            articleFindRequest.sourceIn(), articleFindRequest.publishDateFrom(),
+            articleFindRequest.publishDateTo());
+
+        boolean hasNext = pages.hasNext();
+
+        Object cursor;
+        if (hasNext && !articles.isEmpty() && articleFindRequest.orderBy()
+            .equals(ArticleOrderBy.publishDate)) {
+            cursor = articleDtos.get(articleDtos.size() - 1).publishDate();
+        } else {
+            cursor = null;
+        }
+
+        Instant after =
+            (hasNext && !articles.isEmpty()) ? articles.get(articles.size() - 1).getCreatedAt()
+                : null;
+
+        return new CursorPageResponseArticleDto(articleDtos, cursor, after, articles.size(),
+            totalElements, hasNext);
+    }
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/service/ArticleServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/service/ArticleServiceImpl.java
@@ -112,6 +112,16 @@ public class ArticleServiceImpl implements ArticleService {
                 articleFindRequest.cursor(),
                 articleFindRequest.after(),
                 pageable);
+        } else if (articleFindRequest.orderBy().equals(ArticleOrderBy.commentCount)) {
+            slices = articleCustomRepository.findByCommentCount(articleFindRequest.keyword(),
+                articleFindRequest.interestId(),
+                articleFindRequest.sourceIn(),
+                articleFindRequest.publishDateFrom(),
+                articleFindRequest.publishDateTo(),
+                articleFindRequest.direction(),
+                articleFindRequest.cursor(),
+                articleFindRequest.after(),
+                pageable);
         } else {
             slices = null;
         }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/service/ArticleServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/service/ArticleServiceImpl.java
@@ -25,6 +25,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 
 @Slf4j
@@ -39,6 +40,7 @@ public class ArticleServiceImpl implements ArticleService {
     private final ArticleCustomRepository articleCustomRepository;
     private final CommentRepository commentRepository;
 
+    @Transactional
     @Override
     public ArticleViewDto createUserArticleView(UUID userId, UUID articleId) {
 
@@ -100,6 +102,16 @@ public class ArticleServiceImpl implements ArticleService {
                 articleFindRequest.cursor(),
                 articleFindRequest.after(),
                 pageable);
+        } else if (articleFindRequest.orderBy().equals(ArticleOrderBy.viewCount)) {
+            slices = articleCustomRepository.findByViewCount(articleFindRequest.keyword(),
+                articleFindRequest.interestId(),
+                articleFindRequest.sourceIn(),
+                articleFindRequest.publishDateFrom(),
+                articleFindRequest.publishDateTo(),
+                articleFindRequest.direction(),
+                articleFindRequest.cursor(),
+                articleFindRequest.after(),
+                pageable);
         } else {
             slices = null;
         }
@@ -128,12 +140,14 @@ public class ArticleServiceImpl implements ArticleService {
 
         boolean hasNext = slices.hasNext();
 
-        Object cursor;
-        if (hasNext && !articles.isEmpty() && articleFindRequest.orderBy()
-            .equals(ArticleOrderBy.publishDate)) {
-            cursor = articleDtos.get(articleDtos.size() - 1).publishDate();
-        } else {
-            cursor = null;
+        Object cursor = null;
+        if (hasNext && !articles.isEmpty()) {
+            ArticleDto last = articleDtos.get(articleDtos.size() - 1);
+            switch (articleFindRequest.orderBy()) {
+                case publishDate -> cursor = last.publishDate();
+                case viewCount -> cursor = last.viewCount();
+                case commentCount -> cursor = last.commentCount();
+            }
         }
 
         Instant after =

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/service/ArticleServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/service/ArticleServiceImpl.java
@@ -20,9 +20,9 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
@@ -88,10 +88,10 @@ public class ArticleServiceImpl implements ArticleService {
     @Override
     public CursorPageResponseArticleDto findAll(UUID userId,
         ArticleFindRequest articleFindRequest) {
-        Page<Article> pages;
+        Slice<Article> slices;
         Pageable pageable = PageRequest.of(0, articleFindRequest.limit(), Sort.unsorted());
         if (articleFindRequest.orderBy().equals(ArticleOrderBy.publishDate)) {
-            pages = articleCustomRepository.findByPublishDate(articleFindRequest.keyword(),
+            slices = articleCustomRepository.findByPublishDate(articleFindRequest.keyword(),
                 articleFindRequest.interestId(),
                 articleFindRequest.sourceIn(),
                 articleFindRequest.publishDateFrom(),
@@ -101,10 +101,10 @@ public class ArticleServiceImpl implements ArticleService {
                 articleFindRequest.after(),
                 pageable);
         } else {
-            pages = null;
+            slices = null;
         }
 
-        List<Article> articles = pages.getContent();
+        List<Article> articles = slices.getContent();
         List<ArticleDto> articleDtos = new ArrayList<>();
         articles.stream().forEach(article -> {
             Long commentCount = commentRepository.countByArticle(article);
@@ -126,7 +126,7 @@ public class ArticleServiceImpl implements ArticleService {
             articleFindRequest.sourceIn(), articleFindRequest.publishDateFrom(),
             articleFindRequest.publishDateTo());
 
-        boolean hasNext = pages.hasNext();
+        boolean hasNext = slices.hasNext();
 
         Object cursor;
         if (hasNext && !articles.isEmpty() && articleFindRequest.orderBy()

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/article/service/ArticleServiceTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/article/service/ArticleServiceTest.java
@@ -10,8 +10,10 @@ import com.codeit.team2.monew.module.domain.article.entity.Article;
 import com.codeit.team2.monew.module.domain.article.entity.ArticleView;
 import com.codeit.team2.monew.module.domain.article.mapper.ArticleMapper;
 import com.codeit.team2.monew.module.domain.article.mapper.ArticleMapperImpl;
+import com.codeit.team2.monew.module.domain.article.repository.ArticleCustomRepository;
 import com.codeit.team2.monew.module.domain.article.repository.ArticleRepository;
 import com.codeit.team2.monew.module.domain.article.repository.ArticleViewRepository;
+import com.codeit.team2.monew.module.domain.comment.repository.CommentRepository;
 import com.codeit.team2.monew.module.domain.relation.entity.ArticleInterest;
 import com.codeit.team2.monew.module.domain.user.entity.User;
 import com.codeit.team2.monew.module.domain.user.repository.UserRepository;
@@ -39,12 +41,14 @@ public class ArticleServiceTest {
     private ArticleViewRepository articleViewRepository;
     private ArticleMapper articleMapper;
     private ArticleService articleService;
+    private ArticleCustomRepository articleCustomRepository;
+    private CommentRepository commentRepository;
 
     @BeforeEach
     void setup() {
         articleMapper = new ArticleMapperImpl();
         articleService = new ArticleServiceImpl(articleRepository, articleViewRepository,
-            userRepository, articleMapper);
+            userRepository, articleMapper, articleCustomRepository, commentRepository);
     }
 
     @Test


### PR DESCRIPTION
## 구현 내용

뉴스 기사 목록 조회
- 하나의 검색어로 다음의 속성 중 하나라도 부분일치하는 데이터를 검색할 수 있습니다.
    - 제목, 요약
- 다음의 속성으로 조회할 수 있습니다.
    - 관심사, 출처, 날짜
    - 조회 조건이 여러 개인 경우 모든 조건을 만족한 결과로 조회합니다.
- 다음의 속성으로 정렬 및 커서 페이지네이션을 구현합니다.
    - 날짜, 댓글 수, 조회 수
    - 선택적으로 1개의 정렬 조건만 가질 수 있습니다.

### 구현된 API 엔드포인트
<!-- 구현한 API 엔드포인트 목록을 작성해주세요 -->
- GET /api/articles


### 주요 변경사항
<!-- 주요 변경사항을 작성해주세요 -->
- 기사 목록 조회 API 구현
- QueryDSL 적용
- 

## 테스트 완료 사항
<!-- 테스트한 항목에 체크(x)해주세요 -->
- [ ] 단위 테스트
- [ ] 통합 테스트
- [x] API 테스트 (Swagger/Postman 등)
- [ ] 기타 테스트

## 스크린샷
<!-- 필요한 경우 관련 스크린샷을 첨부해주세요 -->

아직 단위테스트, 통합 테스트는 못하고
포스트맨으로만 확인했습니다.

정렬, hasNext, totalElements 등 모두 확인하였습니다.
![image](https://github.com/user-attachments/assets/d8fa8715-1349-47cc-b74a-4ef379a01db5)


## 체크리스트
<!-- 제출 전 확인해야 할 사항들입니다 -->
- [x] 코딩, 커밋 컨벤션 준수
- [x] 모든 테스트 통과
- [x] API 명세 준수
- [x] 불필요한 로그, 주석, 미사용 코드 제거

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #87

## 추가 코멘트 (선택)
<!-- 리뷰어에게 전달할 추가 정보가 있다면 작성해주세요 -->

## TODO
코드가 많이 지저분합니다. 추가 쿼리도 아주 많이 발생하고 있습니다. 일단 정상 실행되는 것에 초점을 두었습니다...
추후 아마 레포지토리 내에서 join을 이용해 아예 ```Slice<ArticleDto>```를 반환하는 식으로 생각하고 있습니다.

## 제안사항
Article 엔티티 구조 변경
- ArticleDto에는 viewCount와 commentCount가 모두 필요한데, 현재 Article 엔티티에는 commentCount가 없어 따로 commentRepository에서 count를 해야 합니다. 
- 🚀 Article 엔티티에 commentCount가 있어야 쿼리 수를 줄이고, 쿼리도 간소화할 수 있다고 봅니다.

## 공유사항

SQL문
- publishCount 기준 정렬
```
SELECT DISTINCT a.*
FROM articles a
LEFT JOIN article_interests ai ON a.id = ai.article_id
LEFT JOIN interests i ON ai.interest_id = i.id
WHERE a.deleted = false
  AND (
    a.title LIKE '%<keyword>%' OR
    a.summary LIKE '%<keyword>%'
  )
  AND i.id = <interestId>
  AND a.source IN (<sourceList>)
  AND a.published_date >= <publishDateFrom>
  AND a.published_date <= <publishDateTo>
  AND (
    (a.published_date > <publishDateCursor> OR 
    (a.published_date = <publishDateCursor> AND a.created_at > <after>))
    OR
    (a.published_date < <publishDateCursor> OR 
    (a.published_date = <publishDateCursor> AND a.created_at < <after>))
  )
ORDER BY a.published_date <direction>, a.created_at <direction>
LIMIT <pageSize + 1>;
```

- viewCount 기준 정렬 
```
SELECT DISTINCT a.*
FROM articles a
LEFT JOIN article_interests ai ON a.id = ai.article_id
LEFT JOIN interests i ON ai.interest_id = i.id
WHERE a.deleted = false
  AND (
    a.title LIKE '%<keyword>%' OR
    a.summary LIKE '%<keyword>%'
  )
  AND i.id = <interestId>
  AND a.source IN (<sourceList>)
  AND a.published_date >= <publishDateFrom>
  AND a.published_date <= <publishDateTo>
  AND (
    (a.view_count > <viewCountCursor> OR 
    (a.view_count = <viewCountCursor> AND a.created_at > <after>))
    OR
    (a.view_count < <viewCountCursor> OR 
    (a.view_count = <viewCountCursor> AND a.created_at < <after>))
  )
ORDER BY a.view_count <direction>, a.created_at <direction>
LIMIT <pageSize + 1>;
```

- commentCount 기준 정렬
```
SELECT DISTINCT a.*
FROM articles a
LEFT JOIN article_interests ai ON a.id = ai.article_id
LEFT JOIN interests i ON ai.interest_id = i.id
LEFT JOIN comments c ON c.article_id = a.id
WHERE a.deleted = false
  AND (
    a.title LIKE '%<keyword>%' OR
    a.summary LIKE '%<keyword>%'
  )
  AND i.id = <interestId>
  AND a.source IN (<sourceList>)
  AND a.published_date >= <publishDateFrom>
  AND a.published_date <= <publishDateTo>
  AND (
    (COUNT(c.id) > <commentCursor> OR 
    (COUNT(c.id) = <commentCursor> AND a.created_at > <after>))
    OR
    (COUNT(c.id) < <commentCursor> OR 
    (COUNT(c.id) = <commentCursor> AND a.created_at < <after>))
  )
GROUP BY a.id
ORDER BY COUNT(c.id) <direction>, a.created_at <direction>
LIMIT <pageSize + 1>;

```