### PR TITLE
Feat/#78/interest list

### DIFF
--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/controller/InterestController.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/controller/InterestController.java
@@ -1,7 +1,9 @@
 package com.codeit.team2.monew.module.domain.interest.controller;
 
+import com.codeit.team2.monew.module.domain.interest.dto.request.CursorPageRequestInterestDto;
 import com.codeit.team2.monew.module.domain.interest.dto.request.InterestRegisterRequest;
 import com.codeit.team2.monew.module.domain.interest.dto.request.InterestUpdateRequest;
+import com.codeit.team2.monew.module.domain.interest.dto.response.CursorPageResponseInterestDto;
 import com.codeit.team2.monew.module.domain.interest.dto.response.InterestDto;
 import com.codeit.team2.monew.module.domain.interest.service.InterestService;
 import com.codeit.team2.monew.module.domain.subscription.dto.SubscriptionDto;
@@ -13,6 +15,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -64,7 +68,8 @@ public class InterestController {
     ) {
         log.info("Start - InterestController/subscriptione: interest id={}, userId={}", id, userId);
         SubscriptionDto subscriptionDto = subscriptionService.subscription(id, userId);
-        log.info("Complete - InterestController/subscription: interest id={}, userId={}", id, userId);
+        log.info("Complete - InterestController/subscription: interest id={}, userId={}", id,
+            userId);
 
         return ResponseEntity.status(HttpStatus.OK)
             .body(subscriptionDto);
@@ -81,6 +86,17 @@ public class InterestController {
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
             .build();
+    }
+
+    @GetMapping("")
+    public ResponseEntity<CursorPageResponseInterestDto> findAll(
+        @RequestHeader("Monew-Request-User-ID") UUID userId, @Valid @ModelAttribute
+    CursorPageRequestInterestDto cursorPageRequestInterestDto) {
+        log.info("Start - InterestController/findAll");
+        CursorPageResponseInterestDto result = interestService.findAll(userId,
+            cursorPageRequestInterestDto);
+        log.info("Complete - InterestController / findAll");
+        return ResponseEntity.ok(result);
     }
 
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/dto/request/CursorPageRequestInterestDto.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/dto/request/CursorPageRequestInterestDto.java
@@ -1,0 +1,19 @@
+package com.codeit.team2.monew.module.domain.interest.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+import org.springframework.data.domain.Sort.Direction;
+
+public record CursorPageRequestInterestDto(
+    String keyword,
+    @NotNull
+    InterestOrderBy orderBy,
+    @NotNull
+    Direction direction,
+    Object cursor,
+    Instant after,
+    @NotNull
+    int limit
+) {
+
+}

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/dto/request/InterestOrderBy.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/dto/request/InterestOrderBy.java
@@ -1,0 +1,6 @@
+package com.codeit.team2.monew.module.domain.interest.dto.request;
+
+public enum InterestOrderBy {
+    name,
+    subscriberCount
+}

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/dto/response/CursorPageResponseInterestDto.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/dto/response/CursorPageResponseInterestDto.java
@@ -1,0 +1,15 @@
+package com.codeit.team2.monew.module.domain.interest.dto.response;
+
+import java.time.Instant;
+import java.util.List;
+
+public record CursorPageResponseInterestDto(
+    List<InterestDto> content,
+    Object nextCursor,
+    Instant nextAfter,
+    int size,
+    long totalElements,
+    boolean hasNext
+) {
+
+}

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/repository/InterestCustomRepository.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/repository/InterestCustomRepository.java
@@ -1,0 +1,16 @@
+package com.codeit.team2.monew.module.domain.interest.repository;
+
+import com.codeit.team2.monew.module.domain.interest.dto.request.InterestOrderBy;
+import com.codeit.team2.monew.module.domain.interest.entity.Interest;
+import java.time.Instant;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort.Direction;
+
+public interface InterestCustomRepository {
+
+    Slice<Interest> findAll(String keyword, InterestOrderBy orderBy, Direction direction,
+        Object cursor,
+        Instant after, int limit);
+
+    long countFilteredTotalElements(String keyword, InterestOrderBy orderBy, Direction direction);
+}

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/repository/InterestCustomRepositoryImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/repository/InterestCustomRepositoryImpl.java
@@ -1,0 +1,140 @@
+package com.codeit.team2.monew.module.domain.interest.repository;
+
+import com.codeit.team2.monew.module.domain.interest.dto.request.InterestOrderBy;
+import com.codeit.team2.monew.module.domain.interest.entity.Interest;
+import com.codeit.team2.monew.module.domain.interest.entity.QInterest;
+import com.codeit.team2.monew.module.domain.interest.entity.QInterestKeyword;
+import com.codeit.team2.monew.module.domain.interest.entity.QKeyword;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.Instant;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class InterestCustomRepositoryImpl implements InterestCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    private BooleanBuilder buildCommonFilters(String keyword) {
+        QInterest interest = QInterest.interest;
+        QKeyword keywordEntity = QKeyword.keyword;
+
+        // 검색 조건: Interest.name or Keyword.name 부분일치
+        BooleanBuilder where = new BooleanBuilder();
+        if (keyword != null && !keyword.isBlank()) {
+            where.and(
+                interest.name.contains(keyword)
+                    .or(keywordEntity.name.containsIgnoreCase(keyword))
+            );
+        }
+        return where;
+    }
+
+    @Override
+    public long countFilteredTotalElements(String keyword, InterestOrderBy orderBy,
+        Direction direction) {
+        QInterest interest = QInterest.interest;
+        QInterestKeyword interestKeyword = QInterestKeyword.interestKeyword;
+        QKeyword keywordEntity = QKeyword.keyword;
+
+        return queryFactory
+            .select(interest.countDistinct())
+            .from(interest)
+            .leftJoin(interest.keywords, interestKeyword)
+            .leftJoin(interestKeyword.keyword, keywordEntity)
+            .where(buildCommonFilters(keyword))
+            .fetchOne();
+    }
+
+
+    @Override
+    public Slice<Interest> findAll(String keyword, InterestOrderBy orderBy, Direction direction,
+        Object cursor, Instant after, int limit) {
+        QInterest interest = QInterest.interest;
+        QInterestKeyword interestKeyword = QInterestKeyword.interestKeyword;
+        QKeyword keywordEntity = QKeyword.keyword;
+
+        JPAQuery<Interest> query = queryFactory
+            .selectFrom(interest)
+            .distinct()
+            .leftJoin(interest.keywords, interestKeyword).fetchJoin()   /// 지연 로딩이라 fetchjoin 필요
+            .leftJoin(interestKeyword.keyword, keywordEntity).fetchJoin();
+
+        BooleanBuilder where = buildCommonFilters(keyword);
+
+        // 커서 조건
+        if (cursor != null) {
+            if (orderBy == InterestOrderBy.name) {
+                // Object -> String 형 변환
+                String nameCursor = (String) cursor;
+
+                if (direction == Direction.ASC) {
+                    where.and(interest.name.gt(nameCursor));
+                } else {
+                    where.and(interest.name.lt(nameCursor));
+                }
+
+            } else if (orderBy == InterestOrderBy.subscriberCount) {
+                // Object -> long
+                long countCursor = (long) cursor;
+
+                if (direction == Direction.ASC) {
+                    where.and(
+                        interest.subscriberCount.gt(countCursor)
+                            .or(interest.subscriberCount.eq(countCursor)
+                                .and(interest.createdAt.gt(after)))
+                    );
+                } else {
+                    where.and(
+                        interest.subscriberCount.lt(countCursor)
+                            .or(interest.subscriberCount.eq(countCursor)
+                                .and(interest.createdAt.lt(after)))
+                    );
+                }
+            }
+        }
+
+        query.where(where);
+
+        // 정렬 조건
+        OrderSpecifier<?> orderSpecifier;
+        OrderSpecifier<?> createdAtOrderSpecifier = interest.createdAt.asc(); // 보조 정렬 기준
+
+        if (orderBy == InterestOrderBy.name) {
+            orderSpecifier = direction == Direction.ASC
+                ? interest.name.asc()
+                : interest.name.desc();
+        } else {
+            orderSpecifier = direction == Direction.ASC
+                ? interest.subscriberCount.asc()
+                : interest.subscriberCount.desc();
+
+            createdAtOrderSpecifier = direction == Direction.ASC
+                ? interest.createdAt.asc()
+                : interest.createdAt.desc();
+        }
+
+        query.orderBy(orderSpecifier, createdAtOrderSpecifier);
+
+        // hasNext 확인하기 위해 1개 더 가져옴
+        query.limit(limit + 1);
+
+        List<Interest> results = query.fetch();
+
+        boolean hasNext = results.size() > limit;
+        if (hasNext) {
+            results.remove(limit);
+        }
+
+        return new SliceImpl<>(results, PageRequest.of(0, limit), hasNext);
+    }
+}

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/repository/InterestCustomRepositoryImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/repository/InterestCustomRepositoryImpl.java
@@ -1,5 +1,7 @@
 package com.codeit.team2.monew.module.domain.interest.repository;
 
+import static com.codeit.team2.monew.module.domain.interest.entity.QInterestKeyword.interestKeyword;
+
 import com.codeit.team2.monew.module.domain.interest.dto.request.InterestOrderBy;
 import com.codeit.team2.monew.module.domain.interest.entity.Interest;
 import com.codeit.team2.monew.module.domain.interest.entity.QInterest;
@@ -7,6 +9,7 @@ import com.codeit.team2.monew.module.domain.interest.entity.QInterestKeyword;
 import com.codeit.team2.monew.module.domain.interest.entity.QKeyword;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.Instant;
@@ -31,10 +34,16 @@ public class InterestCustomRepositoryImpl implements InterestCustomRepository {
         // 검색 조건: Interest.name or Keyword.name 부분일치
         BooleanBuilder where = new BooleanBuilder();
         if (keyword != null && !keyword.isBlank()) {
-            where.and(
-                interest.name.contains(keyword)
-                    .or(keywordEntity.name.containsIgnoreCase(keyword))
-            );
+            // 관심사 이름 또는 연결된 키워드 이름 중 하나라도 포함되면
+            where.and(interest.id.in(
+                JPAExpressions
+                    .select(interest.id)
+                    .from(interest)
+                    .leftJoin(interest.keywords, interestKeyword)
+                    .leftJoin(interestKeyword.keyword, keywordEntity)
+                    .where(interest.name.containsIgnoreCase(keyword)
+                        .or(keywordEntity.name.containsIgnoreCase(keyword)))
+            ));
         }
         return where;
     }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/service/InterestService.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/service/InterestService.java
@@ -1,7 +1,9 @@
 package com.codeit.team2.monew.module.domain.interest.service;
 
+import com.codeit.team2.monew.module.domain.interest.dto.request.CursorPageRequestInterestDto;
 import com.codeit.team2.monew.module.domain.interest.dto.request.InterestRegisterRequest;
 import com.codeit.team2.monew.module.domain.interest.dto.request.InterestUpdateRequest;
+import com.codeit.team2.monew.module.domain.interest.dto.response.CursorPageResponseInterestDto;
 import com.codeit.team2.monew.module.domain.interest.dto.response.InterestDto;
 import java.util.UUID;
 
@@ -12,4 +14,7 @@ public interface InterestService {
     InterestDto update(InterestUpdateRequest request, UUID id, UUID userId);
 
     void delete(UUID id, UUID userId);
+
+    CursorPageResponseInterestDto findAll(UUID userId,
+        CursorPageRequestInterestDto cursorPageRequestInterestDto);
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/service/InterestServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/service/InterestServiceImpl.java
@@ -135,7 +135,10 @@ public class InterestServiceImpl implements InterestService {
     @Override
     public CursorPageResponseInterestDto findAll(UUID userId,
         CursorPageRequestInterestDto cursorPageRequestInterestDto) {
-
+        if (!userRepository.existsById(userId)) {
+            log.debug("User Not Found: userId = {}", userId);
+            throw new IllegalArgumentException("User Not Found: userId = {}");
+        }
         Slice<Interest> slices = interestCustomRepository.findAll(
             cursorPageRequestInterestDto.keyword(), cursorPageRequestInterestDto.orderBy(),
             cursorPageRequestInterestDto.direction(), cursorPageRequestInterestDto.cursor(),

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/service/InterestServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/service/InterestServiceImpl.java
@@ -1,12 +1,16 @@
 package com.codeit.team2.monew.module.domain.interest.service;
 
+import com.codeit.team2.monew.module.domain.interest.dto.request.CursorPageRequestInterestDto;
+import com.codeit.team2.monew.module.domain.interest.dto.request.InterestOrderBy;
 import com.codeit.team2.monew.module.domain.interest.dto.request.InterestRegisterRequest;
 import com.codeit.team2.monew.module.domain.interest.dto.request.InterestUpdateRequest;
+import com.codeit.team2.monew.module.domain.interest.dto.response.CursorPageResponseInterestDto;
 import com.codeit.team2.monew.module.domain.interest.dto.response.InterestDto;
 import com.codeit.team2.monew.module.domain.interest.entity.Interest;
 import com.codeit.team2.monew.module.domain.interest.entity.InterestKeyword;
 import com.codeit.team2.monew.module.domain.interest.entity.Keyword;
 import com.codeit.team2.monew.module.domain.interest.mapper.InterestMapper;
+import com.codeit.team2.monew.module.domain.interest.repository.InterestCustomRepository;
 import com.codeit.team2.monew.module.domain.interest.repository.InterestKeywordRepository;
 import com.codeit.team2.monew.module.domain.interest.repository.InterestRepository;
 import com.codeit.team2.monew.module.domain.interest.repository.KeywordRepository;
@@ -14,18 +18,20 @@ import com.codeit.team2.monew.module.domain.subscription.repository.Subscription
 import com.codeit.team2.monew.module.domain.user.entity.User;
 import com.codeit.team2.monew.module.domain.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class InterestServiceImpl implements InterestService{
+public class InterestServiceImpl implements InterestService {
 
     private final InterestMapper interestMapper;
     private final UserRepository userRepository;
@@ -33,6 +39,7 @@ public class InterestServiceImpl implements InterestService{
     private final KeywordRepository keywordRepository;
     private final InterestKeywordRepository interestKeywordRepository;
     private final SubscriptionRepository subscriptionRepository;
+    private final InterestCustomRepository interestCustomRepository;
 
     @Override
     @Transactional
@@ -43,7 +50,7 @@ public class InterestServiceImpl implements InterestService{
 
         // TODO: 추후에 index 추가 예정
         // 참고: pg_trgm 특성상 유사도 계산 알고리즘이 달라 사람이 판단하는 것과 다름. 보완 필요
-        if(interestRepository.existsByNameSimilarTo(request.name())) {
+        if (interestRepository.existsByNameSimilarTo(request.name())) {
             throw new IllegalArgumentException("비슷한 관심사가 이미 존재합니다.");
         }
 
@@ -73,9 +80,9 @@ public class InterestServiceImpl implements InterestService{
         boolean subscribedByMe = subscriptionRepository.existsByInterestAndUser(interest, user);
 
         Map<String, InterestKeyword> savedKeywords = interest.getKeywords().stream()
-            .collect(Collectors.toMap(ik -> ik.getKeyword().getName(), ik-> ik ));
+            .collect(Collectors.toMap(ik -> ik.getKeyword().getName(), ik -> ik));
 
-        for (String keyword: request.keywords()) {
+        for (String keyword : request.keywords()) {
             if (!savedKeywords.containsKey(keyword)) {
                 Keyword getKeyword = keywordRepository.findByName(keyword)
                     .orElseGet(() -> keywordRepository.save(new Keyword(keyword)));
@@ -125,4 +132,49 @@ public class InterestServiceImpl implements InterestService{
             () -> new RuntimeException("interest not found"));
     }
 
+    @Override
+    public CursorPageResponseInterestDto findAll(UUID userId,
+        CursorPageRequestInterestDto cursorPageRequestInterestDto) {
+
+        Slice<Interest> slices = interestCustomRepository.findAll(
+            cursorPageRequestInterestDto.keyword(), cursorPageRequestInterestDto.orderBy(),
+            cursorPageRequestInterestDto.direction(), cursorPageRequestInterestDto.cursor(),
+            cursorPageRequestInterestDto.after(), cursorPageRequestInterestDto.limit());
+
+        List<InterestDto> interestDtos = slices.getContent().stream()
+            .map(interest -> toDto(interest, userId))
+            .collect(Collectors.toList());
+
+        long totalElements = interestCustomRepository.countFilteredTotalElements(
+            cursorPageRequestInterestDto.keyword(), cursorPageRequestInterestDto.orderBy(),
+            cursorPageRequestInterestDto.direction());
+
+        boolean hasNext = slices.hasNext();
+
+        Object nextCursor = null;
+        Instant nextAfter = null;
+
+        if (hasNext) {
+            Interest lastInterest = slices.getContent().get(slices.getContent().size() - 1);
+
+            if (cursorPageRequestInterestDto.orderBy() == InterestOrderBy.name) {
+                nextCursor = lastInterest.getName();
+            } else if (cursorPageRequestInterestDto.orderBy() == InterestOrderBy.subscriberCount) {
+                nextCursor = lastInterest.getSubscriberCount();
+                nextAfter = lastInterest.getCreatedAt();
+            }
+        }
+
+        return new CursorPageResponseInterestDto(interestDtos, nextCursor, nextAfter,
+            interestDtos.size(), totalElements, hasNext);
+    }
+
+    private InterestDto toDto(Interest interest, UUID userId) {
+        User user = getUserOrThrow(userId);
+        boolean subscribedByMe = subscriptionRepository.existsByInterestAndUser(interest, user);
+        List<String> keywords = interest.getKeywords().stream()
+            .map(ik -> ik.getKeyword().getName())
+            .collect(Collectors.toList());
+        return interestMapper.toDto(interest, keywords, subscribedByMe);
+    }
 }

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/interest/service/InterestServiceImplTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/interest/service/InterestServiceImplTest.java
@@ -7,12 +7,16 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.codeit.team2.monew.module.domain.interest.TestInterestFactory;
+import com.codeit.team2.monew.module.domain.interest.dto.request.CursorPageRequestInterestDto;
+import com.codeit.team2.monew.module.domain.interest.dto.request.InterestOrderBy;
 import com.codeit.team2.monew.module.domain.interest.dto.request.InterestRegisterRequest;
 import com.codeit.team2.monew.module.domain.interest.dto.request.InterestUpdateRequest;
+import com.codeit.team2.monew.module.domain.interest.dto.response.CursorPageResponseInterestDto;
 import com.codeit.team2.monew.module.domain.interest.dto.response.InterestDto;
 import com.codeit.team2.monew.module.domain.interest.entity.Interest;
 import com.codeit.team2.monew.module.domain.interest.entity.Keyword;
 import com.codeit.team2.monew.module.domain.interest.mapper.InterestMapper;
+import com.codeit.team2.monew.module.domain.interest.repository.InterestCustomRepository;
 import com.codeit.team2.monew.module.domain.interest.repository.InterestKeywordRepository;
 import com.codeit.team2.monew.module.domain.interest.repository.InterestRepository;
 import com.codeit.team2.monew.module.domain.interest.repository.KeywordRepository;
@@ -31,6 +35,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort.Direction;
 
 @ExtendWith(MockitoExtension.class)
 class InterestServiceImplTest {
@@ -49,6 +57,8 @@ class InterestServiceImplTest {
 
     @Mock
     private SubscriptionRepository subscriptionRepository;
+    @Mock
+    private InterestCustomRepository interestCustomRepository;
 
     @Spy
     private InterestMapper interestMapper = Mappers.getMapper(InterestMapper.class);
@@ -138,7 +148,7 @@ class InterestServiceImplTest {
             .thenReturn(false);
 
         // when
-        InterestDto result = interestService.update(request, interest.getId() ,user.getId());
+        InterestDto result = interestService.update(request, interest.getId(), user.getId());
 
         // then
         assertThat(result.keywords()).hasSize(1)
@@ -176,5 +186,48 @@ class InterestServiceImplTest {
         // then
         verify(interestRepository).delete(any(Interest.class));
         verify(keywordRepository).deleteAllOrphanKeywords();
+    }
+
+    @DisplayName("관심사 목록을 조회한다.")
+    @Test
+    void findAll() {
+        // given
+        User user = TestUserFactory.createWithName("name");
+        UUID userId = user.getId();
+        when(userRepository.existsById(userId)).thenReturn(true);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        CursorPageRequestInterestDto cursorPageRequestInterestDto = new CursorPageRequestInterestDto(
+            null,
+            InterestOrderBy.name, Direction.DESC, null, null, 3);
+
+        Interest interest = TestInterestFactory.create("interest1", List.of("k1", "k2"));
+        Slice<Interest> slices = new SliceImpl<>(List.of(interest), PageRequest.of(0, 3), false);
+        when(interestCustomRepository.findAll(cursorPageRequestInterestDto.keyword(),
+            cursorPageRequestInterestDto.orderBy(), cursorPageRequestInterestDto.direction(),
+            cursorPageRequestInterestDto.cursor(), cursorPageRequestInterestDto.after(),
+            cursorPageRequestInterestDto.limit())).thenReturn(slices);
+
+        when(interestCustomRepository.countFilteredTotalElements(any(), any(), any())).thenReturn(
+            1L);
+
+        when(subscriptionRepository.existsByInterestAndUser(interest, user)).thenReturn(false);
+
+        //when
+        CursorPageResponseInterestDto result = interestService.findAll(userId,
+            cursorPageRequestInterestDto);
+
+        // then
+        assertThat(result.content()).hasSize(1);
+        assertThat(result.totalElements()).isEqualTo(1L);
+        assertThat(result.hasNext()).isEqualTo(false);
+        assertThat(result.nextCursor()).isNull();
+        assertThat(result.nextAfter()).isNull();
+        verify(userRepository).existsById(userId);
+        verify(interestCustomRepository).findAll(cursorPageRequestInterestDto.keyword(),
+            cursorPageRequestInterestDto.orderBy(), cursorPageRequestInterestDto.direction(),
+            cursorPageRequestInterestDto.cursor(), cursorPageRequestInterestDto.after(),
+            cursorPageRequestInterestDto.limit());
+
     }
 }


### PR DESCRIPTION
## 구현 내용
<!-- 구현한 기능에 대한 간략한 설명을 작성해주세요 -->

관심사 목록 조회
- 검색어로 다음의 속성 중 하나라도 부분일치하는 데이터를 검색할 수 있습니다.
    - 관심사 이름, 키워드
- 다음의 속성으로 정렬 및 커서 페이지네이션을 구현합니다.
    - 관심사 이름, 구독자 수


### 구현된 API 엔드포인트
<!-- 구현한 API 엔드포인트 목록을 작성해주세요 -->
<!-- 예시:
- GET /api/employees - 직원 목록 조회
- POST /api/employees - 직원 등록
- GET /api/employees/{id} - 직원 상세 조회
- PATCH /api/employees/{id} - 직원 정보 수정
- DELETE /api/employees/{id} - 직원 삭제
- GET /api/employees/stats/trend - 직원 수 추이 조회
- GET /api/employees/stats/distribution - 직원 분포 조회
- GET /api/employees/count - 직원 수 조회 -->
- GET /api/interests - 관심사 목록 조회


### 주요 변경사항
<!-- 주요 변경사항을 작성해주세요 -->
- 관심사 목록 조회 API 구현
- QueryDSL 적용하여 커스텀 레포지토리 추가
- 

## 테스트 완료 사항
<!-- 테스트한 항목에 체크(x)해주세요 -->
- [x] 단위 테스트
- [ ] 통합 테스트
- [x] API 테스트 (Swagger/Postman 등)
- [x] 기타 테스트: 프론트 통합 테스트

## 스크린샷
<!-- 필요한 경우 관련 스크린샷을 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/6f1397b9-70ab-48a7-87c0-37575bedf2e3)


## 체크리스트
<!-- 제출 전 확인해야 할 사항들입니다 -->
- [x] 코딩, 커밋 컨벤션 준수
- [x] 모든 테스트 통과
- [x] API 명세 준수
- [x] 불필요한 로그, 주석, 미사용 코드 제거

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #78

## 추가 코멘트 (선택)
<!-- 리뷰어에게 전달할 추가 정보가 있다면 작성해주세요 -->

쿼리 N+1 문제는 이후 리팩토링 단계에서 해결해보겠습니다.

사용한 SQL문
- 날짜 기준 ASC 정렬
```
SELECT DISTINCT i.*
FROM interest i
LEFT JOIN interest_keyword ik ON i.id = ik.interest_id
LEFT JOIN keyword k ON ik.keyword_id = k.id
WHERE i.id IN (
    SELECT DISTINCT i_sub.id
    FROM interest i_sub
    LEFT JOIN interest_keyword ik_sub ON i_sub.id = ik_sub.interest_id
    LEFT JOIN keyword k_sub ON ik_sub.keyword_id = k_sub.id
    WHERE i_sub.name ILIKE '%{keyword}%'
       OR k_sub.name ILIKE '%{keyword}%'
)
AND (
    i.subscriber_count > {cursor} 
    OR (i.subscriber_count = {cursor} AND i.created_at > '{after}') 
)
ORDER BY i.subscriber_count ASC, i.created_at ASC
LIMIT {limit + 1};
```
- DESC 정렬
```
AND (
    i.subscriber_count < {cursor}
    OR (i.subscriber_count = {cursor} AND i.created_at < '{after}')
)
ORDER BY i.subscriber_count DESC, i.created_at DESC
```

---

- 이름 기준 ASC 정렬
```
SELECT DISTINCT i.*
FROM interest i
LEFT JOIN interest_keyword ik ON i.id = ik.interest_id
LEFT JOIN keyword k ON ik.keyword_id = k.id
WHERE (i.name ILIKE '%{keyword}%' OR k.name ILIKE '%{keyword}%')
  AND i.name > '{cursor}'
ORDER BY i.name ASC
LIMIT {limit + 1};
```

- DESC 정렬
```
WHERE (i.name ILIKE '%{keyword}%' OR k.name ILIKE '%{keyword}%')
  AND i.name < '{cursor}'
ORDER BY i.name DESC
```
