### PR TITLE
[Refactor]: 복구 서비스 - 트랜잭션 처리 개선

### DIFF
--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/backup/controller/ArticleRestoreController.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/backup/controller/ArticleRestoreController.java
@@ -1,20 +1,17 @@
 package com.codeit.team2.monew.module.domain.article.backup.controller;
 
+import com.codeit.team2.monew.module.domain.article.backup.dto.ArticleRestoreResultDto;
 import com.codeit.team2.monew.module.domain.article.backup.service.ArticleRestoreService;
 import java.time.LocalDate;
 import java.util.List;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import com.codeit.team2.monew.module.domain.article.backup.dto.ArticleRestoreResultDto;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestController

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/backup/service/ArticleRestoreService.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/backup/service/ArticleRestoreService.java
@@ -20,12 +20,11 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.BatchPreparedStatementSetter;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
@@ -42,11 +41,10 @@ public class ArticleRestoreService {
     private final S3Client s3Client;
     private final ObjectMapper objectMapper;
     private final JdbcTemplate jdbcTemplate;
+    private final ArticleRestoreTransactionService transactionService;
 
     @Value("${aws.s3.bucket-name}")
     private String bucketName;
-
-    private static final int BATCH_SIZE = 200;
 
     /**
      * 시작 날짜부터 종료 날짜까지 기사 복원
@@ -60,8 +58,9 @@ public class ArticleRestoreService {
         while (!current.isAfter(to)) {
             LocalDate dateToProcess = current;
             try {
-                // 각 날짜를 별도 트랜잭션으로 처리
-                ArticleRestoreResultDto result = processDateWithNewTransaction(dateToProcess);
+                ArticleRestoreResultDto result = transactionService.processDateWithNewTransaction(
+                    this, dateToProcess);
+
                 results.add(result);
                 log.info("Restored {} articles for date {}", result.restoredArticleCount(), dateToProcess);
             } catch (Exception e) {
@@ -80,17 +79,9 @@ public class ArticleRestoreService {
     }
 
     /**
-     * 날짜별 복원 처리
+     * 특정 날짜 기사 복원 - transactionService에서 호출
      */
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public ArticleRestoreResultDto processDateWithNewTransaction(LocalDate date) {
-        return restoreArticlesByDate(date);
-    }
-
-    /**
-     * 특정 날짜 기사 복원
-     */
-    private ArticleRestoreResultDto restoreArticlesByDate(LocalDate date) {
+    ArticleRestoreResultDto restoreArticlesByDate(LocalDate date) {
         String formattedDate = date.format(DateTimeFormatter.ISO_LOCAL_DATE);
         String prefix = "articles/" + formattedDate + "/";
 
@@ -119,8 +110,8 @@ public class ArticleRestoreService {
         for (S3Object s3Object : allObjects) {
             try {
                 log.info("Processing backup file: {}", s3Object.key());
-                // 각 파일 새 트랜잭션으로 처리
-                ProcessFileResult result = processFileWithNewTransaction(s3Object, existingUrls);
+                ProcessFileResult result = transactionService.processFileWithNewTransaction(
+                    this, s3Object, existingUrls);
 
                 if (result.success) {
                     restoredIds.addAll(result.savedIds);
@@ -158,10 +149,9 @@ public class ArticleRestoreService {
     }
 
     /**
-     * 파일 처리
+     * 백업파일 처리 - 트랜잭션 서비스에서 호출
      */
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public ProcessFileResult processFileWithNewTransaction(S3Object s3Object, Set<String> existingUrls) {
+    ProcessFileResult processBackupFileWithTransaction(S3Object s3Object, Set<String> existingUrls) {
         try {
             List<Article> articles = processBackupFile(s3Object, existingUrls);
             if (!articles.isEmpty()) {
@@ -181,7 +171,7 @@ public class ArticleRestoreService {
     }
 
     /**
-     * 기사 일괄 삽입: BatchPreparedStatementSetter 사용
+     * 기사 일괄 삽입 - BatchPreparedStatementSetter 사용
      */
     private List<UUID> batchInsertArticles(List<Article> articles) {
         final List<UUID> savedIds = new ArrayList<>();
@@ -223,7 +213,7 @@ public class ArticleRestoreService {
     /**
      * 파일 처리 결과
      */
-    private static class ProcessFileResult {
+    public static class ProcessFileResult {
         final boolean success;
         final List<UUID> savedIds;
         final Set<String> processedUrls;
@@ -278,19 +268,7 @@ public class ArticleRestoreService {
                         continue;
                     }
 
-                    Article article = new Article(
-                        dto.title(),
-                        dto.source(),
-                        dto.sourceUrl(),
-                        dto.summary(),
-                        new HashSet<>(), // 관심사 관계 추후 고려
-                        dto.viewCount(),
-                        dto.publishedDate(),
-                        dto.deleted()
-                    );
-
-                    // 기본 키 설정 - 백업 데이터의 id를 그대로 사용
-                    article.setId(dto.id()); // BaseEntity에 setter 사용(추후 변경 고려)
+                    Article article = recreateArticle(dto);
 
                     articlesToRestore.add(article);
                 } catch (Exception e) {
@@ -315,7 +293,6 @@ public class ArticleRestoreService {
      * @return
      */
     private List<S3Object> getAllS3Objects(String prefix) {
-
         List<S3Object> allObjects = new ArrayList<>();
         String continuationToken = null;
 
@@ -334,5 +311,22 @@ public class ArticleRestoreService {
         } while (continuationToken != null);
 
         return allObjects;
+    }
+
+    @NotNull
+    private static Article recreateArticle(ArticleBackupDto dto) {
+        Article article = new Article(
+            dto.title(),
+            dto.source(),
+            dto.sourceUrl(),
+            dto.summary(),
+            new HashSet<>(),
+            dto.viewCount(),
+            dto.publishedDate(),
+            dto.deleted()
+        );
+
+        article.setId(dto.id());
+        return article;
     }
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/backup/service/ArticleRestoreTransactionService.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/backup/service/ArticleRestoreTransactionService.java
@@ -1,0 +1,37 @@
+package com.codeit.team2.monew.module.domain.article.backup.service;
+
+
+import com.codeit.team2.monew.module.domain.article.backup.dto.ArticleRestoreResultDto;
+import java.time.LocalDate;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+/**
+ * 복구 서비스 트랜잭션 처리 담당
+ */
+@Service
+@RequiredArgsConstructor
+public class ArticleRestoreTransactionService {
+
+    /**
+     * 날짜별 복원 처리
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public ArticleRestoreResultDto processDateWithNewTransaction(
+        ArticleRestoreService restoreService, LocalDate date) {
+        return restoreService.restoreArticlesByDate(date);
+    }
+
+    /**
+     * 파일 처리
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public ArticleRestoreService.ProcessFileResult processFileWithNewTransaction(
+        ArticleRestoreService restoreService, S3Object s3Object, Set<String> existingUrls) {
+        return restoreService.processBackupFileWithTransaction(s3Object, existingUrls);
+    }
+}


### PR DESCRIPTION
## 구현 내용
<!-- 구현한 기능에 대한 간략한 설명을 작성해주세요 -->
복구 서비스에서 트랜잭션이 올바르지 않게 설계되어 self-invocation 문제가 있었고 이를 개선하였습니다. 

### 구현된 API 엔드포인트
<!-- 구현한 API 엔드포인트 목록을 작성해주세요 -->
<!-- 예시:
- GET /api/employees - 직원 목록 조회
- POST /api/employees - 직원 등록
- GET /api/employees/{id} - 직원 상세 조회
- PATCH /api/employees/{id} - 직원 정보 수정
- DELETE /api/employees/{id} - 직원 삭제
- GET /api/employees/stats/trend - 직원 수 추이 조회
- GET /api/employees/stats/distribution - 직원 분포 조회
- GET /api/employees/count - 직원 수 조회 -->
- GET /api/articles/restore


### 주요 변경사항
<!-- 주요 변경사항을 작성해주세요 -->
- 트랜잭션이 필요한 메서드를 별도의 서비스(ArticleRestoreTransactionService)로 분리하여 self-invocation 문제를 해결하였습니다.

## 테스트 완료 사항
<!-- 테스트한 항목에 체크(x)해주세요 -->
- [ ] 단위 테스트
- [ ] 통합 테스트
- [x] API 테스트 (Swagger/Postman 등)
- [ ] 기타 테스트

## 스크린샷
<!-- 필요한 경우 관련 스크린샷을 첨부해주세요 -->

## 체크리스트
<!-- 제출 전 확인해야 할 사항들입니다 -->
- [x] 코딩, 커밋 컨벤션 준수
- [x] 모든 테스트 통과
- [x] API 명세 준수
- [x] 불필요한 로그, 주석, 미사용 코드 제거

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #103

## 추가 코멘트 (선택)
<!-- 리뷰어에게 전달할 추가 정보가 있다면 작성해주세요 -->
로깅 개선과 테스트는 추후 별도의 pr로 올리겠습니다.