### PR TITLE
[Chore]: t2.micro 환경에서 OOM 이슈 관련 설정 수정 및 버전 자동화 구현, EC2 스왑 영역 설정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,14 @@ jobs:
           distribution: 'temurin'
           cache: gradle
 
+      - name: Extract Version from build.gradle
+        id: extract_version
+        run: |
+          VERSION=$(grep "version = " ./monew/build.gradle | sed "s/version = '\(.*\)'/\1/")
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "Extracted version: $VERSION"
+      
+
       - name: Grant Execution Permission
         run: chmod +x ./gradlew
         working-directory: ./monew
@@ -58,9 +66,10 @@ jobs:
 
       - name: Build And Push
         run: |
-          docker build -t $ECR_REPOSITORY_URI:$IMAGE_TAG -t $ECR_REPOSITORY_URI:latest . --platform linux/amd64
+          docker build --build-arg VERSION=${{ env.VERSION }} -t $ECR_REPOSITORY_URI:$IMAGE_TAG -t $ECR_REPOSITORY_URI:latest -t $ECR_REPOSITORY_URI:${{ env.VERSION }} . --platform linux/amd64
           docker push $ECR_REPOSITORY_URI:$IMAGE_TAG
           docker push $ECR_REPOSITORY_URI:latest
+          docker push $ECR_REPOSITORY_URI:${{ env.VERSION }}
         working-directory: ./monew
 
   deploy:
@@ -71,6 +80,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Extract Version from build.gradle
+        id: extract_version
+        run: |
+          VERSION=$(grep "version = " ./monew/build.gradle | sed "s/version = '\(.*\)'/\1/")
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "Extracted version: $VERSION"
+
       - name: AWS CLI 설정
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -80,19 +96,21 @@ jobs:
 
       - name: Update Task Definition with Environment Variables
         run: |
-          cat ${{ env.ECS_TASK_DEFINITION }} | jq --arg java_opts "${{ env.JAVA_OPTS }}" --arg profile "${{ env.SPRING_PROFILES_ACTIVE }}" '
+          cat ${{ env.ECS_TASK_DEFINITION }} | jq --arg java_opts "${{ env.JAVA_OPTS }}" --arg profile "${{ env.SPRING_PROFILES_ACTIVE }}" --arg version "${{ env.VERSION }}" '
           if .containerDefinitions[0].environment then 
             .containerDefinitions[0].environment += [
               {"name": "JAVA_OPTS", "value": $java_opts},
-              {"name": "SPRING_PROFILES_ACTIVE", "value": $profile}
+              {"name": "SPRING_PROFILES_ACTIVE", "value": $profile},
+              {"name": "PROJECT_VERSION", "value": $version}
             ]
           else 
             .containerDefinitions[0].environment = [
               {"name": "JAVA_OPTS", "value": $java_opts},
-              {"name": "SPRING_PROFILES_ACTIVE", "value": $profile}
+              {"name": "SPRING_PROFILES_ACTIVE", "value": $profile},
+              {"name": "PROJECT_VERSION", "value": $version}
             ]
           end' > updated-task-def.json
-          mv updated-task-def.json ${{ env.ECS_TASK_DEFINITION }}
+          mv updated-task-def.json ${{ env.ECS_TASK_DEFINITION }}  
 
       - name: ECS 테스크 정의
         id: render-task-definition
@@ -100,7 +118,7 @@ jobs:
         with:
           task-definition: ${{ env.ECS_TASK_DEFINITION }}
           container-name: monew-app
-          image: ${{ env.ECR_REPOSITORY_URI }}:${{ env.IMAGE_TAG }}
+          image: ${{ env.ECR_REPOSITORY_URI }}:${{ env.VERSION }}
 
       - name: ECS 서비스 중지(프리티어 환경 고려)
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 name: CD - Deploy To ECS
 
 on:
-  pull_request:
+  push:
     branches:
       - release*
       - release
@@ -18,6 +18,9 @@ env:
   ECS_TASK_DEFINITION: .github/workflows/ecs/task-definition.json
   ECS_SERVICE: monew-service
   ECS_CLUSTER: monew-cluster
+  JAVA_OPTS: "-Xmx350m -Xms256m -XX:MaxMetaspaceSize=128m -XX:+UseG1GC -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/app/logs/heapdump.hprof"
+  SPRING_PROFILES_ACTIVE: "prod"
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -47,7 +50,6 @@ jobs:
           aws-access-key-id: ${{ env.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ env.AWS_SECRET_KEY }}
           aws-region: ${{ env.AWS_REGION }}
-        
 
       - name: ECR Login
         uses: aws-actions/amazon-ecr-login@v2
@@ -66,17 +68,31 @@ jobs:
     needs: build-and-push
 
     steps:
-
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      
       - name: AWS CLI 설정
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ env.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ env.AWS_SECRET_KEY }}
           aws-region: ${{ env.AWS_REGION }}
+
+      - name: Update Task Definition with Environment Variables
+        run: |
+          cat ${{ env.ECS_TASK_DEFINITION }} | jq --arg java_opts "${{ env.JAVA_OPTS }}" --arg profile "${{ env.SPRING_PROFILES_ACTIVE }}" '
+          if .containerDefinitions[0].environment then 
+            .containerDefinitions[0].environment += [
+              {"name": "JAVA_OPTS", "value": $java_opts},
+              {"name": "SPRING_PROFILES_ACTIVE", "value": $profile}
+            ]
+          else 
+            .containerDefinitions[0].environment = [
+              {"name": "JAVA_OPTS", "value": $java_opts},
+              {"name": "SPRING_PROFILES_ACTIVE", "value": $profile}
+            ]
+          end' > updated-task-def.json
+          mv updated-task-def.json ${{ env.ECS_TASK_DEFINITION }}
 
       - name: ECS 테스크 정의
         id: render-task-definition
@@ -92,7 +108,7 @@ jobs:
             --cluster ${{ env.ECS_CLUSTER }} \
             --service ${{ env.ECS_SERVICE }} \
             --desired-count 0
-        
+
       - name: ECS 배포
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1
         with:

--- a/.github/workflows/ecs/task-definition.json
+++ b/.github/workflows/ecs/task-definition.json
@@ -14,12 +14,18 @@
       "image": "replace-me",
       "cpu": 256,
       "memory": 512,
-      "memoryReservation": 256,
+      "memoryReservation": 384,
       "essential": true,
+      "environment": [
+        {
+          "name": "SPRING_PROFILES_ACTIVE",
+          "value": "prod"
+        }
+      ],
       "environmentFiles": [
         {
-            "value": "arn:aws:s3:::monew-article-backup-dev/monew.env",
-            "type": "s3"
+          "value": "arn:aws:s3:::monew-article-backup-dev/monew.env",
+          "type": "s3"
         }
       ],
       "portMappings": [
@@ -39,7 +45,7 @@
           "awslogs-region": "ap-northeast-2",
           "awslogs-stream-prefix": "ecs",
           "mode": "non-blocking",
-          "max-buffer-size": "25m"
+          "max-buffer-size": "15m"
         }
       }
     }

--- a/monew/Dockerfile
+++ b/monew/Dockerfile
@@ -13,7 +13,8 @@ FROM amazoncorretto:17-alpine
 WORKDIR /app
 
 ENV PROJECT_NAME=monew
-ENV PROJECT_VERSION=v1.0.0
+ARG VERSION=v1.0.0
+ENV PROJECT_VERSION=${VERSION}
 ENV JAVA_OPTS="-Xmx350m -Xms256m -XX:MaxMetaspaceSize=128m -XX:+UseG1GC -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/app/logs/heapdump.hprof"
 
 RUN mkdir -p /app/logs && chmod 755 /app/logs

--- a/monew/Dockerfile
+++ b/monew/Dockerfile
@@ -1,21 +1,24 @@
-
 FROM amazoncorretto:17-alpine AS builder
 WORKDIR /app
 
 COPY gradlew .
 COPY gradle/ gradle/
 COPY build.gradle settings.gradle ./
+RUN ./gradlew dependencies --no-daemon
+
 COPY src/ src/
-
 RUN ./gradlew clean build -x test --no-daemon
-
 
 FROM amazoncorretto:17-alpine
 WORKDIR /app
 
 ENV PROJECT_NAME=monew
 ENV PROJECT_VERSION=v1.0.0
-ENV JVM_OPTS=""
+ENV JAVA_OPTS="-Xmx350m -Xms256m -XX:MaxMetaspaceSize=128m -XX:+UseG1GC -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/app/logs/heapdump.hprof"
+
+RUN mkdir -p /app/logs && chmod 755 /app/logs
+
 COPY --from=builder /app/build/libs/${PROJECT_NAME}-${PROJECT_VERSION}.jar app.jar
 EXPOSE 80
-ENTRYPOINT ["sh", "-c", "exec java -Xmx384m -Xms256m -XX:MaxMetaspaceSize=256m -XX:+UseSerialGC -jar app.jar --server.port=80 --spring.profiles.active=prod"]
+
+ENTRYPOINT ["sh", "-c", "exec java ${JAVA_OPTS} -jar app.jar --server.port=80 --spring.profiles.active=${SPRING_PROFILES_ACTIVE:-prod}"]

--- a/monew/build.gradle
+++ b/monew/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'com.codeit.team2'
-version = 'v1.0.0'
+version = 'v1.0.1'
 
 
 java {
@@ -119,13 +119,13 @@ jacocoTestReport {
 // 테스트 태스크 분리
 tasks.register('unitTest', Test) {
     useJUnitPlatform {
-        excludeTags 'integration'  // 'integration' 태그가 없는 테스트만 실행
+        excludeTags 'integration'
     }
 }
 
 tasks.register('integrationTest', Test) {
     useJUnitPlatform {
-        includeTags 'integration'  // 'integration' 태그가 있는 테스트만 실행
+        includeTags 'integration'
     }
 }
 


### PR DESCRIPTION
## 구현 내용
현재 ECS 환경(t2.micro)에서 메모리 부족으로 발생하는 OOM(Out of Memory) 오류를 해결하고, 릴리즈 과정에서 버전 관리를 자동화하기 위해 설정을 수정하였습니다.

## 변경 사항
- Dockerfile: 의존성 단계 분리로 빌드 캐싱 효율화, JVM 메모리 설정 최적화 및 OOM 발생시 힙 덤프 파일 생성 설정, 버전 변수 추가
- task-definition.json: 메모리 설정 및 로그 버퍼 사이즈 조정
- deploy.yml: 트리거 조건 변경(기존 pr 올라올 때 -> pr release로 merge 될 때), 버전 추출 로직 추가
- 버전 정보 v1.0.1로 변경 (버전이 올바르게 반영되는지 확인하기 위함)

### 현재 메모리 상태 확인(스왑 영역 추가 이전)
<img width="651" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/55ab7f67-0b16-407b-8f9f-56b8e77bf640" />

- 총 메모리: 952MB (t2.micro)
- 사용 중인 메모리: 657MB (총 메모리의 약 70%)
- 여유 메모리: 69MB (적음)
- 가용 메모리: 159MB (버퍼/캐시 포함)
- 스왑 메모리: 0B (설정되지 않음)

### 스왑 메모리 설정 (스왑 공간 설정: 2GB)
<img width="653" alt="Pasted Graphic 5" src="https://github.com/user-attachments/assets/5953ccb8-e0c5-46de-9714-2f27b0b2c653" />

- 기대 효과: 총 가용 메모리(952MB) -> 952MB + 2GB 스왑으로 충분한 메모리 공간 확보로 서비스 안정성 향상

### 커널 파라미터 최적화
```bash
echo "vm.swappiness=10" >> /etc/sysctl.conf
echo "vm.vfs_cache_pressure=50" >> /etc/sysctl.conf
sysctl -p
```
- vm.swappiness=10: RAM에 여유가 있을 때는 스왑 사용을 최소화하고, 메모리가 심각하게 부족할 때만 스왑 사용 (기본값 60)
- vm.vfs_cache_pressure=50: 파일 시스템 캐시를 적절히 유지하여 파일 액세스 성능 향상 (기본값 100)

## 체크리스트
<!-- 제출 전 확인해야 할 사항들입니다 -->
- [x] 코딩, 커밋 컨벤션 준수
- [ ] 모든 테스트 통과
- [x] API 명세 준수
- [x] 불필요한 로그, 주석, 미사용 코드 제거

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #131 

## 추가 코멘트 (선택)
<!-- 리뷰어에게 전달할 추가 정보가 있다면 작성해주세요 -->
- 추후 메모리 사용량 모니터링을 통해 설정값 조정할 예정입니다.
