### PR TITLE
Feat/#130/article read refactor #130

### DIFF
--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/mapper/ArticleMapper.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/mapper/ArticleMapper.java
@@ -1,6 +1,7 @@
 package com.codeit.team2.monew.module.domain.article.mapper;
 
 
+import com.codeit.team2.monew.module.domain.article.dto.ArticleDto;
 import com.codeit.team2.monew.module.domain.article.dto.ArticleViewDto;
 import com.codeit.team2.monew.module.domain.article.dto.NaverArticleItemDto;
 import com.codeit.team2.monew.module.domain.article.dto.rss.ChosunRss;
@@ -86,5 +87,8 @@ public interface ArticleMapper {
     ArticleViewDto toResponseDto(Article article, ArticleView articleView, UUID userId,
         int commentCount);
 
-
+    @Mapping(target = "commentCount", source = "commentCount")
+    @Mapping(target = "viewedByMe", source = "viewedByMe")
+    @Mapping(target = "publishDate", source = "article.publishedDate")
+    ArticleDto toDto(Article article, Long commentCount, boolean viewedByMe);
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/repository/ArticleCustomRepository.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/repository/ArticleCustomRepository.java
@@ -1,51 +1,17 @@
 package com.codeit.team2.monew.module.domain.article.repository;
 
 import com.codeit.team2.monew.module.domain.article.dto.request.ArticleSourceIn;
+import com.codeit.team2.monew.module.domain.article.dto.request.CursorPageRequestArticleDto;
 import com.codeit.team2.monew.module.domain.article.entity.Article;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.Sort.Direction;
 
 public interface ArticleCustomRepository {
 
-    Slice<Article> findByPublishDate(
-        String keyword,
-        UUID interestId,
-        List<ArticleSourceIn> sourceIn,
-        Instant publishDateFrom,
-        Instant publishDateTo,
-        Direction direction,
-        String cursor,
-        Instant after,
-        Pageable pageable
-    );
-
-    Slice<Article> findByViewCount(
-        String keyword,
-        UUID interestId,
-        List<ArticleSourceIn> sourceIn,
-        Instant publishDateFrom,
-        Instant publishDateTo,
-        Direction direction,
-        String cursor,
-        Instant after,
-        Pageable pageable
-    );
-
-    Slice<Article> findByCommentCount(
-        String keyword,
-        UUID interestId,
-        List<ArticleSourceIn> sourceIn,
-        Instant publishDateFrom,
-        Instant publishDateTo,
-        Direction direction,
-        String cursor,
-        Instant after,
-        Pageable pageable
-    );
+    Slice<Article> findWithCursor(CursorPageRequestArticleDto request);
+    
 
     long countFilteredTotalElements(String keyword, UUID interestId,
         List<ArticleSourceIn> sourceIn, Instant publishDateFrom, Instant publishDateTo);

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/repository/ArticleCustomRepositoryImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/repository/ArticleCustomRepositoryImpl.java
@@ -1,20 +1,22 @@
 package com.codeit.team2.monew.module.domain.article.repository;
 
+import com.codeit.team2.monew.module.domain.article.dto.request.ArticleOrderBy;
 import com.codeit.team2.monew.module.domain.article.dto.request.ArticleSourceIn;
+import com.codeit.team2.monew.module.domain.article.dto.request.CursorPageRequestArticleDto;
 import com.codeit.team2.monew.module.domain.article.entity.Article;
 import com.codeit.team2.monew.module.domain.article.entity.QArticle;
 import com.codeit.team2.monew.module.domain.comment.entity.QComment;
 import com.codeit.team2.monew.module.domain.relation.entity.QArticleInterest;
 import com.querydsl.core.BooleanBuilder;
-import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort.Direction;
@@ -26,9 +28,10 @@ public class ArticleCustomRepositoryImpl implements ArticleCustomRepository {
 
     private final JPAQueryFactory queryFactory;
 
+    // 필터링 조건 where절 구하기
     private BooleanBuilder buildCommonFilters(QArticle article, QArticleInterest articleInterest,
         String keyword, UUID interestId, List<ArticleSourceIn> sourceIn,
-        Instant publishDateFrom, Instant publishDateTo, JPAQuery<Article> query) {
+        Instant publishDateFrom, Instant publishDateTo) {
 
         BooleanBuilder where = new BooleanBuilder();
 
@@ -43,8 +46,7 @@ public class ArticleCustomRepositoryImpl implements ArticleCustomRepository {
 
         // 관심사 필터링(ArticleInterest와 join 필요)
         if (interestId != null) {
-            query.leftJoin(article.articleInterests, articleInterest);
-            where.and(articleInterest.interest.id.eq(interestId));
+            where.and(article.articleInterests.any().interest.id.eq(interestId));
         }
 
         // 출처 필터링
@@ -64,6 +66,151 @@ public class ArticleCustomRepositoryImpl implements ArticleCustomRepository {
         return where;
     }
 
+    // 정렬 기준 & 방향에 따른 커서 where절 구하기
+    private BooleanBuilder buildCursor(QArticle article, QComment comment,
+        ArticleOrderBy orderBy, Direction direction,
+        String cursor, Instant after) {
+        BooleanBuilder where = new BooleanBuilder();
+
+        switch (orderBy) {
+            case publishDate -> {
+                Instant publishDateCursor = Instant.parse(cursor);
+                if (direction.isAscending()) {
+                    where.and(article.publishedDate.gt(publishDateCursor))
+                        .or(article.publishedDate.eq(publishDateCursor)
+                            .and(article.createdAt.gt(after)));
+                } else {
+                    where.and(article.publishedDate.lt(publishDateCursor))
+                        .or(article.publishedDate.eq(publishDateCursor)
+                            .and(article.createdAt.lt(after)));
+                }
+            }
+            case viewCount -> {
+                Long viewCountCursor = Long.parseLong(cursor);
+                if (direction.isAscending()) {
+                    where.and(article.viewCount.gt(viewCountCursor))
+                        .or(article.viewCount.eq(viewCountCursor)
+                            .and(article.createdAt.gt(after)));
+                } else {
+                    where.and(article.viewCount.lt(viewCountCursor))
+                        .or(article.viewCount.eq(viewCountCursor)
+                            .and(article.createdAt.lt(after)));
+                }
+            }
+            default -> throw new IllegalArgumentException("Unsupported orderBy");
+        }
+
+        return where;
+    }
+
+    // commentCount 정렬하는 경우 having절 추가
+    private BooleanExpression buildCursorHaving(QArticle article, QComment comment,
+        Direction direction, String cursor, Instant after) {
+        Long commentCountCursor = Long.parseLong(cursor);
+
+        if (direction.isAscending()) {
+            return comment.count().gt(commentCountCursor)
+                .or(comment.count().eq(commentCountCursor)
+                    .and(article.createdAt.gt(after)));
+        } else {
+            return comment.count().lt(commentCountCursor)
+                .or(comment.count().eq(commentCountCursor)
+                    .and(article.createdAt.lt(after)));
+        }
+    }
+
+    // ORDER BY 지정하기
+    private List<OrderSpecifier<?>> buildOrderSpecifiers(QArticle article, QComment comment,
+        ArticleOrderBy orderBy, Direction direction) {
+
+        OrderSpecifier<?> order = switch (orderBy) {
+            case publishDate -> direction.isAscending() ? article.publishedDate.asc()
+                : article.publishedDate.desc();
+            case viewCount ->
+                direction.isAscending() ? article.viewCount.asc() : article.viewCount.desc();
+            case commentCount ->
+                direction.isAscending() ? comment.count().asc() : comment.count().desc();
+        };
+
+        // 보조 커서 createdAt 정렬
+        OrderSpecifier<?> createdAtOrder = direction.isAscending()
+            ? article.createdAt.asc()
+            : article.createdAt.desc();
+
+        return List.of(order, createdAtOrder);
+    }
+
+
+    @Override
+    public Slice<Article> findWithCursor(CursorPageRequestArticleDto request) {
+        String keyword = request.keyword();
+        UUID interestId = request.interestId();
+        List<ArticleSourceIn> sourceIn = request.sourceIn();
+        Instant publishDateFrom = request.getPublishDateFromInstant();
+        Instant publishDateTo = request.getPublishDateToInstant();
+        ArticleOrderBy orderBy = request.orderBy();
+        Direction direction = request.direction();
+        String cursor = request.cursor();
+        Instant after = request.after();
+        int limit = request.limit();
+
+        QArticle article = QArticle.article;
+        QArticleInterest articleInterest = QArticleInterest.articleInterest;
+        QComment comment = QComment.comment;
+
+        // 기본 쿼리: Article에서 select
+        JPAQuery<Article> query = queryFactory.selectFrom(article);
+        // commentCount 정렬이면 comment join 추가
+        if (orderBy.equals(ArticleOrderBy.commentCount)) {
+            query.leftJoin(comment).on(comment.article.eq(article));
+        }
+        // 관심사 조건이 있으면 article interest join 추가
+        if (interestId != null) {
+            query.leftJoin(article.articleInterests, articleInterest);
+        }
+
+        // 검색 조건
+        BooleanBuilder where = buildCommonFilters(article, articleInterest, keyword, interestId,
+            sourceIn, publishDateFrom, publishDateTo);
+
+        // 커서가 있는 경우 where 추가
+        if (cursor != null && after != null) {
+            if (orderBy.equals(ArticleOrderBy.commentCount)) {
+                BooleanExpression cursorCondition = buildCursorHaving(article, comment, direction,
+                    cursor, after);
+                query.having(cursorCondition);
+            } else {
+                BooleanBuilder cursorCondition = buildCursor(article, comment, orderBy, direction,
+                    cursor, after);
+                where.and(cursorCondition);
+            }
+        }
+
+        query.where(where);
+
+        // 정렬 조건
+        List<OrderSpecifier<?>> orderSpecifiers = buildOrderSpecifiers(article, comment, orderBy,
+            direction);
+        for (OrderSpecifier<?> os : orderSpecifiers) {
+            query.orderBy(os);
+        }
+
+        if (orderBy.equals(ArticleOrderBy.commentCount)) {
+            query.groupBy(article.id);
+        }
+
+        query.limit(limit + 1);
+
+        List<Article> result = query.fetch();
+
+        boolean hasNext = result.size() > limit;
+        if (hasNext) {
+            result.remove(limit);
+        }
+
+        return new SliceImpl<>(result, PageRequest.of(0, limit), hasNext);
+    }
+
     @Override
     public long countFilteredTotalElements(String keyword, UUID interestId,
         List<ArticleSourceIn> sourceIn, Instant publishDateFrom, Instant publishDateTo) {
@@ -72,153 +219,9 @@ public class ArticleCustomRepositoryImpl implements ArticleCustomRepository {
 
         JPAQuery<Article> query = queryFactory.selectFrom(article);
         BooleanBuilder where = buildCommonFilters(article, articleInterest,
-            keyword, interestId, sourceIn, publishDateFrom, publishDateTo, query);
+            keyword, interestId, sourceIn, publishDateFrom, publishDateTo);
 
         return query.where(where).fetchCount();
     }
 
-    @Override
-    public Slice<Article> findByPublishDate(String keyword, UUID interestId,
-        List<ArticleSourceIn> sourceIn, Instant publishDateFrom, Instant publishDateTo,
-        Direction direction, String cursor, Instant after, Pageable pageable) {
-
-        QArticle article = QArticle.article;
-        QArticleInterest articleInterest = QArticleInterest.articleInterest;
-
-        JPAQuery<Article> query = queryFactory.selectFrom(article).distinct();
-
-        BooleanBuilder where = buildCommonFilters(article, articleInterest,
-            keyword, interestId, sourceIn, publishDateFrom, publishDateTo, query);
-
-        // 커서 조건 확인: 커서 없으면 생략
-        if (cursor != null && after != null) {
-            // Object -> Instant
-            Instant publishDateCursor = Instant.parse(cursor);
-            // ASC
-            if (direction.isAscending()) {
-                where.and(article.publishedDate.gt(publishDateCursor))
-                    .or(article.publishedDate.eq(publishDateCursor)
-                        .and(article.createdAt.gt(after)));
-            } else {
-                //DESC
-                where.and(article.publishedDate.lt(publishDateCursor))
-                    .or(article.publishedDate.eq(publishDateCursor)
-                        .and(article.createdAt.lt(after)));
-            }
-        }
-
-        query.where(where);
-
-        // 정렬 조건: publishedDate + createdAt
-        Order order = direction.isAscending() ? Order.ASC : Order.DESC;
-        query.orderBy(
-            new OrderSpecifier<>(order, article.publishedDate),
-            new OrderSpecifier<>(order, article.createdAt));
-
-        List<Article> result = query.limit(pageable.getPageSize() + 1).fetch();
-
-        boolean hasNext = result.size() > pageable.getPageSize();
-        if (hasNext) {
-            result.remove(pageable.getPageSize());
-        }
-
-        return new SliceImpl<>(result, pageable, hasNext);
-    }
-
-    @Override
-    public Slice<Article> findByViewCount(String keyword, UUID interestId,
-        List<ArticleSourceIn> sourceIn, Instant publishDateFrom, Instant publishDateTo,
-        Direction direction, String cursor, Instant after, Pageable pageable) {
-        QArticle article = QArticle.article;
-        QArticleInterest articleInterest = QArticleInterest.articleInterest;
-
-        JPAQuery<Article> query = queryFactory.selectFrom(article).distinct();
-
-        BooleanBuilder where = buildCommonFilters(article, articleInterest,
-            keyword, interestId, sourceIn, publishDateFrom, publishDateTo, query);
-
-        // 커서 조건 확인: 커서 없으면 생략
-        if (cursor != null && after != null) {
-            // Object -> Long
-            Long viewCountCursor = Long.parseLong(cursor);
-            // ASC
-            if (direction.isAscending()) {
-                where.and(article.viewCount.gt(viewCountCursor))
-                    .or(article.viewCount.eq(viewCountCursor)
-                        .and(article.createdAt.gt(after)));
-            } else {
-                //DESC
-                where.and(article.viewCount.lt(viewCountCursor))
-                    .or(article.viewCount.eq(viewCountCursor)
-                        .and(article.createdAt.lt(after)));
-            }
-        }
-
-        query.where(where);
-
-        // 정렬 조건: publishedDate + createdAt
-        Order order = direction.isAscending() ? Order.ASC : Order.DESC;
-        query.orderBy(
-            new OrderSpecifier<>(order, article.viewCount),
-            new OrderSpecifier<>(order, article.createdAt));
-
-        List<Article> result = query.limit(pageable.getPageSize() + 1).fetch();
-
-        boolean hasNext = result.size() > pageable.getPageSize();
-        if (hasNext) {
-            result.remove(pageable.getPageSize());
-        }
-
-        return new SliceImpl<>(result, pageable, hasNext);
-    }
-
-    @Override
-    public Slice<Article> findByCommentCount(String keyword, UUID interestId,
-        List<ArticleSourceIn> sourceIn, Instant publishDateFrom, Instant publishDateTo,
-        Direction direction, String cursor, Instant after, Pageable pageable) {
-        QArticle article = QArticle.article;
-        QArticleInterest articleInterest = QArticleInterest.articleInterest;
-        QComment comment = QComment.comment;
-
-        JPAQuery<Article> query = queryFactory
-            .select(article)
-            .from(article)
-            .leftJoin(article.articleInterests, articleInterest)
-            .leftJoin(comment).on(comment.article.eq(article))
-            .groupBy(article.id);
-
-        BooleanBuilder where = buildCommonFilters(article, articleInterest,
-            keyword, interestId, sourceIn, publishDateFrom, publishDateTo, query);
-
-        if (cursor != null && after != null) {
-            Long commentCursor = Long.parseLong(cursor);
-            if (direction.isAscending()) {
-                query.having(comment.count().gt(commentCursor)
-                    .or(comment.count().eq(commentCursor).and(article.createdAt.gt(after))));
-            } else {
-                query.having(comment.count().lt(commentCursor)
-                    .or(comment.count().eq(commentCursor).and(article.createdAt.lt(after))));
-            }
-        }
-
-        query.where(where);
-
-        Order order = direction.isAscending() ? Order.ASC : Order.DESC;
-        query.orderBy(
-            new OrderSpecifier<>(order, comment.count()),
-            // commentCount 기준으로 세야함 -> 쿼리에서 left join으로 가져온 comment의 수
-            new OrderSpecifier<>(order, article.createdAt)
-        );
-
-        List<Article> articles = query
-            .limit(pageable.getPageSize() + 1)
-            .fetch();
-
-        boolean hasNext = articles.size() > pageable.getPageSize();
-        if (hasNext) {
-            articles.remove(pageable.getPageSize());
-        }
-
-        return new SliceImpl<>(articles, pageable, hasNext);
-    }
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/repository/ArticleRepository.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/repository/ArticleRepository.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ArticleRepository extends JpaRepository<Article, UUID> {
+public interface ArticleRepository extends JpaRepository<Article, UUID>, ArticleCustomRepository {
+
     List<Article> findAllBySourceUrlIn(Set<String> sourceUrl);
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/repository/ArticleViewRepository.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/repository/ArticleViewRepository.java
@@ -17,4 +17,6 @@ public interface ArticleViewRepository extends JpaRepository<ArticleView, UUID> 
     List<ArticleView> findTop10ByUserOrderByViewedAtDesc(User user);
 
     boolean existsByUserIdAndArticleId(UUID userId, UUID articleId);
+
+
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/repository/ArticleViewRepository.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/repository/ArticleViewRepository.java
@@ -8,6 +8,8 @@ import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ArticleViewRepository extends JpaRepository<ArticleView, UUID> {
 
@@ -18,5 +20,8 @@ public interface ArticleViewRepository extends JpaRepository<ArticleView, UUID> 
 
     boolean existsByUserIdAndArticleId(UUID userId, UUID articleId);
 
+    @Query("SELECT av.article.id FROM ArticleView av WHERE av.user.id = :userId AND av.article.id IN :articleIds")
+    List<UUID> findViewedArticleIds(@Param("userId") UUID userId,
+        @Param("articleIds") List<UUID> articleIds);
 
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/service/ArticleServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/service/ArticleServiceImpl.java
@@ -14,9 +14,10 @@ import com.codeit.team2.monew.module.domain.comment.repository.CommentRepository
 import com.codeit.team2.monew.module.domain.user.entity.User;
 import com.codeit.team2.monew.module.domain.user.repository.UserRepository;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Slice;
@@ -89,21 +90,25 @@ public class ArticleServiceImpl implements ArticleService {
         Slice<Article> slices = articleCustomRepository.findWithCursor(cursorPageRequestArticleDto);
 
         List<Article> articles = slices.getContent();
-        List<ArticleDto> articleDtos = new ArrayList<>();
-        articles.stream().forEach(article -> {
-            Long commentCount = commentRepository.countByArticle(article);
-            boolean viewedByMe = articleViewRepository.existsByUserIdAndArticleId(userId,
-                article.getId());
-            articleDtos.add(new ArticleDto(article.getId(),
-                article.getSource(),
-                article.getSourceUrl(),
-                article.getTitle(),
-                article.getPublishedDate(),
-                article.getSummary(),
-                commentCount,
-                article.getViewCount(),
-                viewedByMe));
-        });
+        List<UUID> articleIds = articles.stream().map(article -> article.getId())
+            .collect(Collectors.toList());
+        // DTO 매핑을 위해 필요한 값 bulk로 가져오기
+        Map<UUID, Long> commentCountMap = commentRepository.countByArticleIds(articleIds).stream()
+            .collect(Collectors.toMap(
+                row -> (UUID) row[0],  // 첫 번째 컬럼: articleId
+                row -> (Long) row[1]   // 두 번째 컬럼: count
+            ));
+        List<UUID> viewedArticleIds = articleViewRepository.findViewedArticleIds(userId,
+            articleIds);
+
+        // Article -> ArticleDto 매핑
+        List<ArticleDto> articleDtos = articles.stream()
+            .map(article -> {
+                Long commentCount = commentCountMap.getOrDefault(article.getId(), 0L);
+                boolean viewedByMe = viewedArticleIds.contains(article.getId());
+                return articleMapper.toDto(article, commentCount, viewedByMe);
+            })
+            .toList();
 
         long totalElements = articleCustomRepository.countFilteredTotalElements(
             cursorPageRequestArticleDto.keyword(), cursorPageRequestArticleDto.interestId(),

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/service/ArticleServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/service/ArticleServiceImpl.java
@@ -7,7 +7,6 @@ import com.codeit.team2.monew.module.domain.article.dto.request.CursorPageReques
 import com.codeit.team2.monew.module.domain.article.entity.Article;
 import com.codeit.team2.monew.module.domain.article.entity.ArticleView;
 import com.codeit.team2.monew.module.domain.article.mapper.ArticleMapper;
-import com.codeit.team2.monew.module.domain.article.repository.ArticleCustomRepository;
 import com.codeit.team2.monew.module.domain.article.repository.ArticleRepository;
 import com.codeit.team2.monew.module.domain.article.repository.ArticleViewRepository;
 import com.codeit.team2.monew.module.domain.comment.repository.CommentRepository;
@@ -34,7 +33,6 @@ public class ArticleServiceImpl implements ArticleService {
     private final ArticleViewRepository articleViewRepository;
     private final UserRepository userRepository;
     private final ArticleMapper articleMapper;
-    private final ArticleCustomRepository articleCustomRepository;
     private final CommentRepository commentRepository;
 
     @Transactional
@@ -87,7 +85,7 @@ public class ArticleServiceImpl implements ArticleService {
     @Override
     public CursorPageResponseArticleDto findAll(UUID userId,
         CursorPageRequestArticleDto cursorPageRequestArticleDto) {
-        Slice<Article> slices = articleCustomRepository.findWithCursor(cursorPageRequestArticleDto);
+        Slice<Article> slices = articleRepository.findWithCursor(cursorPageRequestArticleDto);
 
         List<Article> articles = slices.getContent();
         List<UUID> articleIds = articles.stream().map(article -> article.getId())
@@ -110,7 +108,7 @@ public class ArticleServiceImpl implements ArticleService {
             })
             .toList();
 
-        long totalElements = articleCustomRepository.countFilteredTotalElements(
+        long totalElements = articleRepository.countFilteredTotalElements(
             cursorPageRequestArticleDto.keyword(), cursorPageRequestArticleDto.interestId(),
             cursorPageRequestArticleDto.sourceIn(),
             cursorPageRequestArticleDto.getPublishDateFromInstant(),

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/service/ArticleServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/service/ArticleServiceImpl.java
@@ -3,7 +3,6 @@ package com.codeit.team2.monew.module.domain.article.service;
 import com.codeit.team2.monew.module.domain.article.dto.ArticleDto;
 import com.codeit.team2.monew.module.domain.article.dto.ArticleViewDto;
 import com.codeit.team2.monew.module.domain.article.dto.CursorPageResponseArticleDto;
-import com.codeit.team2.monew.module.domain.article.dto.request.ArticleOrderBy;
 import com.codeit.team2.monew.module.domain.article.dto.request.CursorPageRequestArticleDto;
 import com.codeit.team2.monew.module.domain.article.entity.Article;
 import com.codeit.team2.monew.module.domain.article.entity.ArticleView;
@@ -20,10 +19,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -90,43 +86,7 @@ public class ArticleServiceImpl implements ArticleService {
     @Override
     public CursorPageResponseArticleDto findAll(UUID userId,
         CursorPageRequestArticleDto cursorPageRequestArticleDto) {
-        Slice<Article> slices;
-        Pageable pageable = PageRequest.of(0, cursorPageRequestArticleDto.limit(), Sort.unsorted());
-        if (cursorPageRequestArticleDto.orderBy().equals(ArticleOrderBy.publishDate)) {
-            slices = articleCustomRepository.findByPublishDate(
-                cursorPageRequestArticleDto.keyword(),
-                cursorPageRequestArticleDto.interestId(),
-                cursorPageRequestArticleDto.sourceIn(),
-                cursorPageRequestArticleDto.getPublishDateFromInstant(),
-                cursorPageRequestArticleDto.getPublishDateToInstant(),
-                cursorPageRequestArticleDto.direction(),
-                cursorPageRequestArticleDto.cursor(),
-                cursorPageRequestArticleDto.after(),
-                pageable);
-        } else if (cursorPageRequestArticleDto.orderBy().equals(ArticleOrderBy.viewCount)) {
-            slices = articleCustomRepository.findByViewCount(cursorPageRequestArticleDto.keyword(),
-                cursorPageRequestArticleDto.interestId(),
-                cursorPageRequestArticleDto.sourceIn(),
-                cursorPageRequestArticleDto.getPublishDateFromInstant(),
-                cursorPageRequestArticleDto.getPublishDateToInstant(),
-                cursorPageRequestArticleDto.direction(),
-                cursorPageRequestArticleDto.cursor(),
-                cursorPageRequestArticleDto.after(),
-                pageable);
-        } else if (cursorPageRequestArticleDto.orderBy().equals(ArticleOrderBy.commentCount)) {
-            slices = articleCustomRepository.findByCommentCount(
-                cursorPageRequestArticleDto.keyword(),
-                cursorPageRequestArticleDto.interestId(),
-                cursorPageRequestArticleDto.sourceIn(),
-                cursorPageRequestArticleDto.getPublishDateFromInstant(),
-                cursorPageRequestArticleDto.getPublishDateToInstant(),
-                cursorPageRequestArticleDto.direction(),
-                cursorPageRequestArticleDto.cursor(),
-                cursorPageRequestArticleDto.after(),
-                pageable);
-        } else {
-            slices = null;
-        }
+        Slice<Article> slices = articleCustomRepository.findWithCursor(cursorPageRequestArticleDto);
 
         List<Article> articles = slices.getContent();
         List<ArticleDto> articleDtos = new ArrayList<>();

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/repository/CommentRepository.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/repository/CommentRepository.java
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CommentRepository extends JpaRepository<Comment, UUID> {
 
@@ -16,5 +18,9 @@ public interface CommentRepository extends JpaRepository<Comment, UUID> {
     Long countByArticle(Article article);
 
     Long countByArticleId(UUID articleId);
+
+    @Query("SELECT c.article.id, COUNT(c) FROM Comment c WHERE c.article.id IN :articleIds GROUP BY c.article.id")
+    List<Object[]> countByArticleIds(@Param("articleIds") List<UUID> articleIds);
+
 
 }

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/article/controller/ArticleControllerTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/article/controller/ArticleControllerTest.java
@@ -2,19 +2,29 @@ package com.codeit.team2.monew.module.domain.article.controller;
 
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.codeit.team2.monew.module.domain.article.dto.ArticleDto;
 import com.codeit.team2.monew.module.domain.article.dto.ArticleViewDto;
+import com.codeit.team2.monew.module.domain.article.dto.CursorPageResponseArticleDto;
+import com.codeit.team2.monew.module.domain.article.dto.request.ArticleOrderBy;
+import com.codeit.team2.monew.module.domain.article.dto.request.CursorPageRequestArticleDto;
 import com.codeit.team2.monew.module.domain.article.service.ArticleService;
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -76,5 +86,36 @@ public class ArticleControllerTest {
                 .header("Monew-Request-User-Id", userId.toString())
                 .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void findAll_success() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+        CursorPageRequestArticleDto requestDto = new CursorPageRequestArticleDto(
+            null, null, null, null, null, ArticleOrderBy.publishDate, Direction.ASC, null, null, 10
+        );
+        CursorPageResponseArticleDto response = new CursorPageResponseArticleDto(
+            List.of(
+                new ArticleDto(UUID.randomUUID(), "", "", "", Instant.now(), "", 0L, 0L, false)),
+            null, null, 1, 1L, false);
+
+        when(articleService.findAll(eq(userId), any(CursorPageRequestArticleDto.class)))
+            .thenReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/articles")
+                .header("Monew-Request-User-Id", userId.toString())
+                .param("orderBy", "publishDate")
+                .param("direction", "ASC")
+                .param("size", "3")
+                .param("limit", "3")
+            )
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content").isArray())
+            .andExpect(jsonPath("$.content[0].id").exists())
+            .andExpect(jsonPath("$.size").value(1))
+            .andExpect(jsonPath("$.hasNext").value(false));
     }
 }

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/article/service/ArticleServiceTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/article/service/ArticleServiceTest.java
@@ -3,14 +3,21 @@ package com.codeit.team2.monew.module.domain.article.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.codeit.team2.monew.module.TestEntityFactory;
 import com.codeit.team2.monew.module.domain.article.dto.ArticleViewDto;
+import com.codeit.team2.monew.module.domain.article.dto.CursorPageResponseArticleDto;
+import com.codeit.team2.monew.module.domain.article.dto.request.ArticleOrderBy;
+import com.codeit.team2.monew.module.domain.article.dto.request.CursorPageRequestArticleDto;
 import com.codeit.team2.monew.module.domain.article.entity.Article;
 import com.codeit.team2.monew.module.domain.article.entity.ArticleView;
 import com.codeit.team2.monew.module.domain.article.mapper.ArticleMapper;
 import com.codeit.team2.monew.module.domain.article.mapper.ArticleMapperImpl;
-import com.codeit.team2.monew.module.domain.article.repository.ArticleCustomRepository;
 import com.codeit.team2.monew.module.domain.article.repository.ArticleRepository;
 import com.codeit.team2.monew.module.domain.article.repository.ArticleViewRepository;
 import com.codeit.team2.monew.module.domain.comment.repository.CommentRepository;
@@ -18,6 +25,7 @@ import com.codeit.team2.monew.module.domain.relation.entity.ArticleInterest;
 import com.codeit.team2.monew.module.domain.user.entity.User;
 import com.codeit.team2.monew.module.domain.user.repository.UserRepository;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -27,6 +35,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.BDDMockito;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -41,14 +52,14 @@ public class ArticleServiceTest {
     private ArticleViewRepository articleViewRepository;
     private ArticleMapper articleMapper;
     private ArticleService articleService;
-    private ArticleCustomRepository articleCustomRepository;
+    @Mock
     private CommentRepository commentRepository;
 
     @BeforeEach
     void setup() {
         articleMapper = new ArticleMapperImpl();
         articleService = new ArticleServiceImpl(articleRepository, articleViewRepository,
-            userRepository, articleMapper, articleCustomRepository, commentRepository);
+            userRepository, articleMapper, commentRepository);
     }
 
     @Test
@@ -158,4 +169,75 @@ public class ArticleServiceTest {
         assertThatThrownBy(() -> articleService.softDelete(randomId))
             .isInstanceOf(IllegalArgumentException.class);
     }
+
+    @Test
+    void test_findAll() {
+        // given
+        UUID userId = UUID.randomUUID();
+        CursorPageRequestArticleDto requestDto = new CursorPageRequestArticleDto(
+            null, null, null, null, null, ArticleOrderBy.publishDate, Direction.ASC, null, null, 10
+        );
+
+        List<Article> articles = List.of(
+            TestEntityFactory.createArticle("title1"),
+            TestEntityFactory.createArticle("title2")
+        );
+
+        Slice<Article> slices = new SliceImpl<>(articles);
+
+        when(articleRepository.findWithCursor(requestDto)).thenReturn(slices);
+
+        List<Object[]> commentCounts = List.of(
+            new Object[]{articles.get(0).getId(), 5L},
+            new Object[]{articles.get(1).getId(), 3L}
+        );
+
+        when(commentRepository.countByArticleIds(anyList())).thenReturn(commentCounts);
+
+        List<UUID> viewedArticleIds = List.of(articles.get(0).getId(), articles.get(1).getId());
+        when(articleViewRepository.findViewedArticleIds(eq(userId), anyList())).thenReturn(
+            viewedArticleIds);
+
+//        ArticleDto articleDto1 = new ArticleDto(
+//            articles.get(0).getId(),
+//            "source",
+//            "sourceUrl",
+//            "title1",
+//            Instant.now(),
+//            "summary",
+//            5L,   // 댓글 수
+//            10L,  // 조회 수
+//            true   // 내가 본 여부
+//        );
+//
+//        ArticleDto articleDto2 = new ArticleDto(
+//            articles.get(1).getId(),
+//            "source",
+//            "sourceUrl",
+//            "title2",
+//            Instant.now(),
+//            "summary",
+//            3L,   // 댓글 수
+//            8L,   // 조회 수
+//            false  // 내가 본 여부
+//        );
+//
+//        // `articleMapper`의 `toDto()` 메서드가 정확한 `ArticleDto`를 반환하도록 설정
+//        when(articleMapper.toDto(articles.get(0), 5L, true)).thenReturn(articleDto1);
+//        when(articleMapper.toDto(articles.get(1), 3L, false)).thenReturn(articleDto2);
+
+        // when
+        CursorPageResponseArticleDto result = articleService.findAll(userId, requestDto);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.content().size()).isEqualTo(2);
+        assertThat(result.content().get(0).commentCount()).isEqualTo(5L);
+        assertThat(result.content().get(0).viewedByMe()).isTrue();
+
+        verify(articleRepository).findWithCursor(any(CursorPageRequestArticleDto.class));
+        verify(commentRepository).countByArticleIds(anyList());
+        verify(articleViewRepository).findViewedArticleIds(eq(userId), anyList());
+    }
+
 }

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/article/service/ArticleServiceTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/article/service/ArticleServiceTest.java
@@ -198,34 +198,6 @@ public class ArticleServiceTest {
         when(articleViewRepository.findViewedArticleIds(eq(userId), anyList())).thenReturn(
             viewedArticleIds);
 
-//        ArticleDto articleDto1 = new ArticleDto(
-//            articles.get(0).getId(),
-//            "source",
-//            "sourceUrl",
-//            "title1",
-//            Instant.now(),
-//            "summary",
-//            5L,   // 댓글 수
-//            10L,  // 조회 수
-//            true   // 내가 본 여부
-//        );
-//
-//        ArticleDto articleDto2 = new ArticleDto(
-//            articles.get(1).getId(),
-//            "source",
-//            "sourceUrl",
-//            "title2",
-//            Instant.now(),
-//            "summary",
-//            3L,   // 댓글 수
-//            8L,   // 조회 수
-//            false  // 내가 본 여부
-//        );
-//
-//        // `articleMapper`의 `toDto()` 메서드가 정확한 `ArticleDto`를 반환하도록 설정
-//        when(articleMapper.toDto(articles.get(0), 5L, true)).thenReturn(articleDto1);
-//        when(articleMapper.toDto(articles.get(1), 3L, false)).thenReturn(articleDto2);
-
         // when
         CursorPageResponseArticleDto result = articleService.findAll(userId, requestDto);
 


### PR DESCRIPTION
## 구현 내용
<!-- 구현한 기능에 대한 간략한 설명을 작성해주세요 -->
뉴스 기사 목록 조회

### 구현된 API 엔드포인트
<!-- 구현한 API 엔드포인트 목록을 작성해주세요 -->
<!-- 예시:
- GET /api/employees - 직원 목록 조회
- POST /api/employees - 직원 등록
- GET /api/employees/{id} - 직원 상세 조회
- PATCH /api/employees/{id} - 직원 정보 수정
- DELETE /api/employees/{id} - 직원 삭제
- GET /api/employees/stats/trend - 직원 수 추이 조회
- GET /api/employees/stats/distribution - 직원 분포 조회
- GET /api/employees/count - 직원 수 조회 -->
GET /api/articles - 기사 목록 조회



### 주요 변경사항
<!-- 주요 변경사항을 작성해주세요 -->
- 쿼리 줄이기
- 코드 구조 개선
- 컨트롤러 테스트 코드 추가

## 테스트 완료 사항
<!-- 테스트한 항목에 체크(x)해주세요 -->
- [x] 단위 테스트
- [ ] 통합 테스트
- [x] API 테스트 (Swagger/Postman 등)
- [ ] 기타 테스트

## 스크린샷
<!-- 필요한 경우 관련 스크린샷을 첨부해주세요 -->

## 체크리스트
<!-- 제출 전 확인해야 할 사항들입니다 -->
- [x] 코딩, 커밋 컨벤션 준수
- [x] 모든 테스트 통과
- [x] API 명세 준수
- [x] 불필요한 로그, 주석, 미사용 코드 제거

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #130

## 추가 코멘트 (선택)
<!-- 리뷰어에게 전달할 추가 정보가 있다면 작성해주세요 -->

- 리팩토링 이전 쿼리 수(publishDate 기준 정렬, limit 5일 때)
  - Article 조회 1 + 댓글 수 조회 5(N) + 조회 수 조회 5(N) + totalElements 조회 1
- 리팩토링 이후(동일 기준)
  - Article 조회 1 + 댓글 수 bulk 조회 1 + 조회 수 bulk 조회 1 + totalElements 조회 1

Repository에서는 쿼리 변화가 어려워 주로 가독성을 높이기 위한 구조만 개선하고,
쿼리 수는 서비스에서 DTO 매핑에 필요한 데이터를 bulk로 가져오도록 하여 줄였습니다.

기본적으로 limit를 50으로 요청하기 때문에 실행되는 쿼리 수를 98개 줄였다고 볼 수 있습니다.