### PR TITLE
Feat/#145/notf read refactor 알림 조회 리팩토링, 테스트 커버리지

### DIFF
--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/repository/CommentCustomRepositoryImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/repository/CommentCustomRepositoryImpl.java
@@ -35,7 +35,6 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository {
 
         // 커서 조건
         if (cursor != null) {
-            System.out.println("cursor: " + cursor);
             // 날짜 기준 정렬
             if (orderBy.equals(CommentOrderBy.createdAt)) {
                 // Object -> Instant

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/controller/docs/NotificationControllerDocs.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/controller/docs/NotificationControllerDocs.java
@@ -40,7 +40,8 @@ public interface NotificationControllerDocs {
         @ApiResponse(responseCode = "500", description = "서버 내부 오류")
     })
     @GetMapping("")
-    ResponseEntity<CursorPageResponseNotificationDto> findAll(UUID userId, Instant cursor, Instant after, int limit);
+    ResponseEntity<CursorPageResponseNotificationDto> findAll(UUID userId, Instant cursor,
+        Instant after, int limit);
 
     @Operation(
         summary = "전체 알림 확인",

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/dto/CursorPageResponseNotificationDto.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/dto/CursorPageResponseNotificationDto.java
@@ -11,7 +11,7 @@ public record CursorPageResponseNotificationDto(
     List<NotificationDto> content,
 
     @Schema(description = "다음 페이지 커서")
-    Object nextCursor,
+    Instant nextCursor,
 
     @Schema(description = "다음 보조 커서(마지막 요소의 생성 시간)", format = "date-time", example = "2025-04-06T15:04:05.000Z")
     Instant nextAfter,

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/repository/NotificationCustomRepository.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/repository/NotificationCustomRepository.java
@@ -1,0 +1,11 @@
+package com.codeit.team2.monew.module.domain.notification.repository;
+
+import com.codeit.team2.monew.module.domain.notification.entity.Notification;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.data.domain.Slice;
+
+public interface NotificationCustomRepository {
+
+    Slice<Notification> findWithCursor(UUID userId, Instant cursor, UUID after, int limit);
+}

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/repository/NotificationCustomRepository.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/repository/NotificationCustomRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.domain.Slice;
 
 public interface NotificationCustomRepository {
 
-    Slice<Notification> findWithCursor(UUID userId, Instant cursor, UUID after, int limit);
+    Slice<Notification> findWithCursor(UUID userId, Instant cursor, Instant after, int limit);
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/repository/NotificationCustomRepositoryImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/repository/NotificationCustomRepositoryImpl.java
@@ -1,0 +1,49 @@
+package com.codeit.team2.monew.module.domain.notification.repository;
+
+import com.codeit.team2.monew.module.domain.notification.entity.Notification;
+import com.codeit.team2.monew.module.domain.notification.entity.QNotification;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationCustomRepositoryImpl implements NotificationCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<Notification> findWithCursor(UUID userId, Instant cursor, UUID after, int limit) {
+        QNotification notification = QNotification.notification;
+
+        // 확인하지 않은 알림 & 특정 유저의 알림
+        BooleanBuilder where = new BooleanBuilder()
+            .and(notification.user.id.eq(userId))
+            .and(notification.confirmed.isFalse());
+        // 커서 조건
+        if (cursor != null && after != null) {
+            where.and(notification.createdAt.gt(cursor)
+                .or((notification.createdAt.eq(cursor)).and(notification.id.gt(after))));
+        }
+
+        List<Notification> result = queryFactory.select(notification)
+            .where(where)
+            .orderBy(notification.createdAt.asc(), notification.id.asc())
+            .limit(limit + 1)
+            .fetch();
+
+        boolean hasNext = result.size() > limit;
+        if (hasNext) {
+            result.remove(limit);
+        }
+
+        return new SliceImpl<>(result, PageRequest.of(0, limit), hasNext);
+    }
+}

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/repository/NotificationCustomRepositoryImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/repository/NotificationCustomRepositoryImpl.java
@@ -20,7 +20,8 @@ public class NotificationCustomRepositoryImpl implements NotificationCustomRepos
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Slice<Notification> findWithCursor(UUID userId, Instant cursor, UUID after, int limit) {
+    public Slice<Notification> findWithCursor(UUID userId, Instant cursor, Instant after,
+        int limit) {
         QNotification notification = QNotification.notification;
 
         // 확인하지 않은 알림 & 특정 유저의 알림
@@ -29,11 +30,10 @@ public class NotificationCustomRepositoryImpl implements NotificationCustomRepos
             .and(notification.confirmed.isFalse());
         // 커서 조건
         if (cursor != null && after != null) {
-            where.and(notification.createdAt.gt(cursor)
-                .or((notification.createdAt.eq(cursor)).and(notification.id.gt(after))));
+            where.and(notification.createdAt.gt(cursor));
         }
 
-        List<Notification> result = queryFactory.select(notification)
+        List<Notification> result = queryFactory.selectFrom(notification)
             .where(where)
             .orderBy(notification.createdAt.asc(), notification.id.asc())
             .limit(limit + 1)

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/repository/NotificationRepository.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/repository/NotificationRepository.java
@@ -3,8 +3,6 @@ package com.codeit.team2.monew.module.domain.notification.repository;
 import com.codeit.team2.monew.module.domain.notification.entity.Notification;
 import java.time.Instant;
 import java.util.UUID;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -19,20 +17,6 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
     @Modifying
     @Query("DELETE FROM Notification n WHERE n.confirmed = true AND n.createdAt < :time")
     int deleteByConfirmedIsTrueAndCreatedAtBefore(@Param("time") Instant time);
-
-    @Query("SELECT n FROM Notification n "
-        + "WHERE n.user.id = :userId "
-        + "AND n.confirmed = false "
-        + "AND n.createdAt > :cursor "
-        + "ORDER BY n.createdAt ASC, n.id DESC ")
-    Page<Notification> findPageWithCursor(@Param("userId") UUID userId,
-        @Param("cursor") Instant cursor, Pageable pageable);
-
-    @Query("SELECT n FROM Notification n "
-        + "WHERE n.user.id = :userId "
-        + "AND n.confirmed = false "
-        + "ORDER BY n.createdAt ASC, n.id DESC ")
-    Page<Notification> findFirstPage(@Param("userId") UUID userId, Pageable pageable);
 
     @Query("SELECT COUNT(n) FROM Notification  n WHERE n.user.id"
         + "=:userId AND n.confirmed = false ")

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/repository/NotificationRepository.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/repository/NotificationRepository.java
@@ -8,7 +8,8 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface NotificationRepository extends JpaRepository<Notification, UUID> {
+public interface NotificationRepository extends JpaRepository<Notification, UUID>,
+    NotificationCustomRepository {
 
     @Modifying
     @Query("UPDATE Notification n SET n.confirmed = true WHERE n.user.id = :userId AND n.confirmed = false")

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImpl.java
@@ -9,6 +9,7 @@ import com.codeit.team2.monew.module.domain.notification.dto.NotificationDto;
 import com.codeit.team2.monew.module.domain.notification.entity.Notification;
 import com.codeit.team2.monew.module.domain.notification.entity.ResourceType;
 import com.codeit.team2.monew.module.domain.notification.mapper.NotificationMapper;
+import com.codeit.team2.monew.module.domain.notification.repository.NotificationCustomRepository;
 import com.codeit.team2.monew.module.domain.notification.repository.NotificationRepository;
 import com.codeit.team2.monew.module.domain.relation.entity.ArticleInterest;
 import com.codeit.team2.monew.module.domain.subscription.entity.Subscription;
@@ -24,11 +25,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,6 +40,7 @@ public class NotificationServiceImpl implements NotificationService {
     private final CommentRepository commentRepository;
     private final SubscriptionRepository subscriptionRepository;
     private final NotificationMapper notificationMapper;
+    private final NotificationCustomRepository notificationCustomRepository;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Override
@@ -143,21 +141,16 @@ public class NotificationServiceImpl implements NotificationService {
     public CursorPageResponseNotificationDto findAll(UUID userId, Instant cursor, Instant after,
         int limit) {
         // 정렬 조건은 시간 순으로 고정
-        Pageable pageable = PageRequest.of(0, limit, Sort.by(Direction.ASC, "createdAt"));
-        Page<Notification> pages;
-        if (cursor != null) {
-            pages = notificationRepository.findPageWithCursor(userId, cursor, pageable);
-        } else {
-            pages = notificationRepository.findFirstPage(userId, pageable);
-        }
+        Slice<Notification> slices = notificationCustomRepository.findWithCursor(userId, cursor,
+            after, limit);
         // dto로 변환
-        List<Notification> notifications = pages.getContent();
+        List<Notification> notifications = slices.getContent();
         List<NotificationDto> notificationDtos = notifications.stream()
             .map(notification -> notificationMapper.toDto(notification))
             .collect(Collectors.toList());
 
-        int size = pages.getSize();
-        boolean hasNext = pages.hasNext();
+        int size = slices.getSize();
+        boolean hasNext = slices.hasNext();
         Instant nextCursor = null;
         Instant nextAfter = null;
         if (hasNext) {

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImpl.java
@@ -142,10 +142,6 @@ public class NotificationServiceImpl implements NotificationService {
     @Override
     public CursorPageResponseNotificationDto findAll(UUID userId, Instant cursor, Instant after,
         int limit) {
-        if (!userRepository.existsById(userId)) {
-            log.debug("[Notification finding] Failed: User not found - userId: {}", userId);
-            throw new RuntimeException("User Not Found");
-        }
         // 정렬 조건은 시간 순으로 고정
         Pageable pageable = PageRequest.of(0, limit, Sort.by(Direction.ASC, "createdAt"));
         Page<Notification> pages;

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImpl.java
@@ -9,7 +9,6 @@ import com.codeit.team2.monew.module.domain.notification.dto.NotificationDto;
 import com.codeit.team2.monew.module.domain.notification.entity.Notification;
 import com.codeit.team2.monew.module.domain.notification.entity.ResourceType;
 import com.codeit.team2.monew.module.domain.notification.mapper.NotificationMapper;
-import com.codeit.team2.monew.module.domain.notification.repository.NotificationCustomRepository;
 import com.codeit.team2.monew.module.domain.notification.repository.NotificationRepository;
 import com.codeit.team2.monew.module.domain.relation.entity.ArticleInterest;
 import com.codeit.team2.monew.module.domain.subscription.entity.Subscription;
@@ -40,7 +39,6 @@ public class NotificationServiceImpl implements NotificationService {
     private final CommentRepository commentRepository;
     private final SubscriptionRepository subscriptionRepository;
     private final NotificationMapper notificationMapper;
-    private final NotificationCustomRepository notificationCustomRepository;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Override
@@ -141,7 +139,7 @@ public class NotificationServiceImpl implements NotificationService {
     public CursorPageResponseNotificationDto findAll(UUID userId, Instant cursor, Instant after,
         int limit) {
         // 정렬 조건은 시간 순으로 고정
-        Slice<Notification> slices = notificationCustomRepository.findWithCursor(userId, cursor,
+        Slice<Notification> slices = notificationRepository.findWithCursor(userId, cursor,
             after, limit);
         // dto로 변환
         List<Notification> notifications = slices.getContent();

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/notification/repository/NotificationCustomRepositoryImplTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/notification/repository/NotificationCustomRepositoryImplTest.java
@@ -1,0 +1,105 @@
+package com.codeit.team2.monew.module.domain.notification.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.codeit.team2.monew.config.JpaConfig;
+import com.codeit.team2.monew.config.QuerydslConfig;
+import com.codeit.team2.monew.module.domain.notification.entity.Notification;
+import com.codeit.team2.monew.module.domain.notification.entity.ResourceType;
+import com.codeit.team2.monew.module.domain.user.entity.User;
+import com.codeit.team2.monew.module.domain.user.repository.UserRepository;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Slice;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+@DataJpaTest
+@ActiveProfiles("test-temp")
+@Import({JpaConfig.class, QuerydslConfig.class})
+@Transactional
+class NotificationCustomRepositoryTest {
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Qualifier("notificationCustomRepositoryImpl")
+    @Autowired
+    private NotificationCustomRepository notificationCustomRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    private UUID userId;
+
+    @Test
+    void testFindWithCursor_정상작동() {
+        // given: 유저 및 알림 데이터 세팅
+        User user = userRepository.save(new User("email", "nick", "pw", false));
+        userId = user.getId();
+
+        for (int i = 0; i < 5; i++) {
+            Notification n = new Notification(user, "알림" + i, false, UUID.randomUUID(),
+                ResourceType.INTEREST);
+            ReflectionTestUtils.setField(n, "createdAt",
+                Instant.now().minusSeconds(1000 - i * 100));
+            notificationRepository.save(n);
+        }
+        em.flush();
+        em.clear();
+
+        Instant cursor = Instant.now().minusSeconds(850); // 2번째 알림보다 이후
+        Instant after = cursor; // 동일하게 넣음
+        int limit = 2;
+
+        // when
+        Slice<Notification> result = notificationCustomRepository.findWithCursor(userId, cursor,
+            after, limit);
+
+        // then
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.hasNext()).isTrue();
+        assertThat(result.getContent().get(0).getContent()).isEqualTo("알림0");
+        assertThat(result.getContent().get(1).getContent()).isEqualTo("알림1");
+    }
+
+    @Test
+    void testFindWithCursor_확인된알림제외() {
+        // given
+        User user = userRepository.save(new User("email", "nick", "pw", false));
+        userId = user.getId();
+
+        // 확인 안 된 알림
+        Notification n1 = new Notification(user, "미확인", false, UUID.randomUUID(),
+            ResourceType.INTEREST);
+        ReflectionTestUtils.setField(n1, "createdAt", Instant.now().minusSeconds(1000));
+        notificationRepository.save(n1);
+
+        // 확인된 알림
+        Notification n2 = new Notification(user, "확인됨", true, UUID.randomUUID(),
+            ResourceType.INTEREST);
+        ReflectionTestUtils.setField(n2, "createdAt", Instant.now().minusSeconds(900));
+        notificationRepository.save(n2);
+
+        em.flush();
+        em.clear();
+
+        // when
+        Slice<Notification> result = notificationCustomRepository.findWithCursor(userId,
+            Instant.EPOCH, Instant.EPOCH, 10);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getContent()).isEqualTo("미확인");
+    }
+}

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/notification/repository/NotificationRepositoryTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/notification/repository/NotificationRepositoryTest.java
@@ -1,0 +1,101 @@
+package com.codeit.team2.monew.module.domain.notification.repository;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.codeit.team2.monew.config.JpaConfig;
+import com.codeit.team2.monew.config.QuerydslConfig;
+import com.codeit.team2.monew.module.domain.notification.entity.Notification;
+import com.codeit.team2.monew.module.domain.notification.entity.ResourceType;
+import com.codeit.team2.monew.module.domain.user.entity.User;
+import com.codeit.team2.monew.module.domain.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Slice;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DataJpaTest
+@ActiveProfiles("test-temp")
+@Import({JpaConfig.class, QuerydslConfig.class})
+@Transactional
+class NotificationRepositoryTest {
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    private User setupUserWithNotifications() {
+        User user = userRepository.save(new User("email", "name", "password", false));
+        em.flush();
+        em.clear();
+
+        User managedUser = em.find(User.class, user.getId());
+
+        for (int i = 0; i < 2; i++) {
+            notificationRepository.save(
+                new Notification(managedUser, "알림" + i, false, UUID.randomUUID(),
+                    ResourceType.INTEREST));
+        }
+        Notification oldNotification = new Notification(managedUser, "확인된 알림", true,
+            UUID.randomUUID(),
+            ResourceType.INTEREST);
+        ReflectionTestUtils.setField(oldNotification, "createdAt",
+            Instant.now().minus(7, ChronoUnit.DAYS));
+        notificationRepository.save(oldNotification);
+
+        return managedUser;
+    }
+
+    @Test
+    void testConfirmAllByUserId() {
+        User user = setupUserWithNotifications();
+        int updatedCount = notificationRepository.confirmAllByUserId(user.getId());
+        assertThat(updatedCount).isEqualTo(2);
+
+        long remainingUnconfirmed = notificationRepository.countForPagination(user.getId());
+        assertThat(remainingUnconfirmed).isEqualTo(0);
+    }
+
+    @Test
+    void testDeleteByConfirmedIsTrueAndCreatedAtBefore() {
+        User user = setupUserWithNotifications();
+
+        Instant now = Instant.now();
+        int deleted = notificationRepository.deleteByConfirmedIsTrueAndCreatedAtBefore(
+            now);
+        assertThat(deleted).isEqualTo(1);
+    }
+
+    @Test
+    void testCountForPagination() {
+        User user = setupUserWithNotifications();
+
+        long count = notificationRepository.countForPagination(user.getId());
+        assertThat(count).isEqualTo(2);
+    }
+
+    @Test
+    void testFindWithCursor() {
+        User user = setupUserWithNotifications();
+
+        Instant cursor = null;
+        Instant after = null;
+        int limit = 10;
+
+        Slice<Notification> result = notificationRepository.findWithCursor(user.getId(), cursor,
+            after, limit);
+        assertThat(result.getContent().size()).isEqualTo(2);  // 명시적 표현
+    }
+}

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImplTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImplTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -36,8 +37,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -233,7 +235,7 @@ class NotificationServiceImplTest {
         // then
         verify(notificationRepository).confirmAllByUserId(userId);
     }
-    
+
     @DisplayName("알림 전체 확인 - 실패")
     @Test
     void confirmAllNotificationsShouldFail() {
@@ -252,14 +254,14 @@ class NotificationServiceImplTest {
         // given
         User user = mock(User.class);
         UUID userId = UUID.randomUUID();
-        when(userRepository.existsById(userId)).thenReturn(true);
 
         Notification n1 = new Notification(user, "content", UUID.randomUUID(),
             ResourceType.COMMENT);
         Notification n2 = new Notification(user, "content", UUID.randomUUID(),
             ResourceType.COMMENT);
-        Page<Notification> pages = new PageImpl<>(List.of(n1, n2));
-        when(notificationRepository.findFirstPage(any(), any())).thenReturn(pages);
+        Slice<Notification> slices = new SliceImpl<>(List.of(n1, n2), PageRequest.of(0, 5), false);
+        when(notificationRepository.findWithCursor(any(), any(), any(), anyInt())).thenReturn(
+            slices);
         when(notificationRepository.countForPagination(userId)).thenReturn(2L);
         when(notificationMapper.toDto(any(Notification.class))).thenAnswer(invocation -> {
             Notification notification = invocation.getArgument(0);
@@ -275,12 +277,11 @@ class NotificationServiceImplTest {
 
         // then
         assertNotNull(result);
-        assertEquals(2, result.size());
         assertEquals(2L, result.totalElements());
         assertFalse(result.hasNext());
         assertNull(result.nextCursor());
         assertNull(result.nextCursor());
-        verify(notificationRepository).findFirstPage(any(), any());
+        verify(notificationRepository).findWithCursor(any(), any(), any(), anyInt());
         verify(notificationRepository).countForPagination(any());
     }
 

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImplTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImplTest.java
@@ -285,18 +285,6 @@ class NotificationServiceImplTest {
         verify(notificationRepository).countForPagination(any());
     }
 
-    @DisplayName("알림 목록 조회 - 실패: 유저 검증 실패")
-    @Test
-    void findAllShouldFail() {
-        // given
-        UUID userId = UUID.randomUUID();
-        when(userRepository.existsById(userId)).thenReturn(false);
-
-        // when & then
-        assertThrows(RuntimeException.class,
-            () -> notificationService.findAll(userId, null, null, 50));
-    }
-
     @DisplayName("구독한 관심사 관련 기사 등록 시 알림 생성 - 성공")
     @Test
     void createArticleInterestNotification() {


### PR DESCRIPTION
## 구현 내용
<!-- 구현한 기능에 대한 간략한 설명을 작성해주세요 -->
알림 목록 조회 기능에
QueryDSL을 적용하였습니다.

+ 테스트 커버리지 높이기

### 구현된 API 엔드포인트
<!-- 구현한 API 엔드포인트 목록을 작성해주세요 -->
<!-- 예시:
- GET /api/employees - 직원 목록 조회
- POST /api/employees - 직원 등록
- GET /api/employees/{id} - 직원 상세 조회
- PATCH /api/employees/{id} - 직원 정보 수정
- DELETE /api/employees/{id} - 직원 삭제
- GET /api/employees/stats/trend - 직원 수 추이 조회
- GET /api/employees/stats/distribution - 직원 분포 조회
- GET /api/employees/count - 직원 수 조회 -->
- GET /api/notifications 알림 목록 조회

### 주요 변경사항
<!-- 주요 변경사항을 작성해주세요 -->
- Notification QueryDsl 적용
- NotificationRepository 테스트 코드 추가
- 

## 테스트 완료 사항
<!-- 테스트한 항목에 체크(x)해주세요 -->
- [x] 단위 테스트
- [ ] 통합 테스트
- [x] API 테스트 (Swagger/Postman 등)
- [x] 기타 테스트: 프론트 통합

## 스크린샷
<!-- 필요한 경우 관련 스크린샷을 첨부해주세요 -->

## 체크리스트
<!-- 제출 전 확인해야 할 사항들입니다 -->
- [x] 코딩, 커밋 컨벤션 준수
- [x] 모든 테스트 통과
- [x] API 명세 준수
- [x] 불필요한 로그, 주석, 미사용 코드 제거

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #145 

## 추가 코멘트 (선택)
<!-- 리뷰어에게 전달할 추가 정보가 있다면 작성해주세요 -->

#79 에서 중복 가능한 createdAt 대신
고유키인 id를 보조 커서로 해보자고 아이디어를 냈고,
이번에 시도해봤는데
![image](https://github.com/user-attachments/assets/c12e928f-25ec-4c96-ba01-58571e55165f)
포스트맨에서는 가능했는데 프론트 코드와 통합했을 때는 불가능하더라고요.
아마 커서를 null로 보냈을 때는 알아서 마지막 요소의 createdAt을 다음 커서로 보는 것 같습니다.

요구사항대로 createdAt을 메인 커서이자 보조 커서로 사용하는 게 나을 것 같습니다...

그래서 QueryDsl 적용과 코드 구조 정리만 했습니다.

테스트 코드를 추가하여 테스트 커버리지도 올려보려고 합니다.