### PR TITLE
faet: 활동내역 관리 - 수정(완성)

### DIFF
--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/event/InterestUpdateEvent.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/event/InterestUpdateEvent.java
@@ -1,0 +1,13 @@
+package com.codeit.team2.monew.module.domain.interest.event;
+
+import com.codeit.team2.monew.module.domain.interest.entity.Interest;
+import java.util.List;
+import java.util.UUID;
+
+public record InterestUpdateEvent(
+    Interest interest,
+    List<String> keywords,
+    UUID userId
+) {
+
+}

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/service/InterestServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/service/InterestServiceImpl.java
@@ -11,6 +11,7 @@ import com.codeit.team2.monew.module.domain.interest.entity.Interest;
 import com.codeit.team2.monew.module.domain.interest.entity.InterestKeyword;
 import com.codeit.team2.monew.module.domain.interest.entity.Keyword;
 import com.codeit.team2.monew.module.domain.interest.event.InterestDeleteEvent;
+import com.codeit.team2.monew.module.domain.interest.event.InterestUpdateEvent;
 import com.codeit.team2.monew.module.domain.interest.exception.InterestNotFoundException;
 import com.codeit.team2.monew.module.domain.interest.mapper.InterestMapper;
 import com.codeit.team2.monew.module.domain.interest.repository.InterestCustomRepository;
@@ -110,6 +111,13 @@ public class InterestServiceImpl implements InterestService {
         List<String> keywords = interest.getKeywords().stream()
             .map(ik -> ik.getKeyword().getName())
             .collect(Collectors.toList());
+
+        // 관심사 수정 이벤트 발생
+        publisher.publishEvent(new InterestUpdateEvent(
+            interest,
+            keywords,
+            userId
+        ));
 
         return interestMapper.toDto(interest, keywords, subscribedByMe);
     }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/user/TestDataInitializer.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/user/TestDataInitializer.java
@@ -13,6 +13,7 @@ import com.codeit.team2.monew.module.domain.comment.repository.CommentRepository
 import com.codeit.team2.monew.module.domain.comment.service.CommentLikeService;
 import com.codeit.team2.monew.module.domain.comment.service.CommentService;
 import com.codeit.team2.monew.module.domain.interest.dto.request.InterestRegisterRequest;
+import com.codeit.team2.monew.module.domain.interest.dto.request.InterestUpdateRequest;
 import com.codeit.team2.monew.module.domain.interest.dto.response.InterestDto;
 import com.codeit.team2.monew.module.domain.interest.service.InterestService;
 import com.codeit.team2.monew.module.domain.subscription.service.SubscriptionService;
@@ -154,7 +155,11 @@ public class TestDataInitializer implements ApplicationRunner {
         InterestDto interestDto = interestService.create(request, userDto.id());
 
         subscriptionService.subscription(interestDto.id(), userDto.id());
-        subscriptionService.cancelSubscription(interestDto.id(), userDto.id());
+
+        InterestUpdateRequest updateRequest = new InterestUpdateRequest(
+            List.of("ruby", "javascript", "dart")
+        );
+        interestService.update(updateRequest, interestDto.id(), userDto.id());
     }
 
     void initUserRegisterEventData() {

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/document/SubscriptionItem.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/document/SubscriptionItem.java
@@ -21,5 +21,9 @@ public class SubscriptionItem {
     private List<String> interestKeywords;
     private Long interestSubscriberCount;
     private Instant createdAt;
+
+    public void updateInterestKeywords(List<String> keywords) {
+        this.interestKeywords = keywords;
+    }
 }
 

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/listener/InterestEventListener.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/listener/InterestEventListener.java
@@ -1,6 +1,7 @@
 package com.codeit.team2.monew.module.domain.useractivity.listener;
 
 import com.codeit.team2.monew.module.domain.interest.event.InterestDeleteEvent;
+import com.codeit.team2.monew.module.domain.interest.event.InterestUpdateEvent;
 import com.codeit.team2.monew.module.domain.useractivity.service.MongoUserActivityService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -16,11 +17,19 @@ public class InterestEventListener {
     private final MongoUserActivityService userActivityService;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void updateSubscriptionItem(InterestUpdateEvent event) {
+        userActivityService.updateSubscriptionItemInActivity(
+            event.interest(),
+            event.keywords(),
+            event.userId()
+        );
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void deleteSubscriptionItem(InterestDeleteEvent event) {
         userActivityService.deleteSubscriptionItem(
             event.interest(),
             event.userId()
         );
     }
-
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/service/MongoUserActivityService.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/service/MongoUserActivityService.java
@@ -39,8 +39,7 @@ public class MongoUserActivityService implements UserActivityService {
             throw new RuntimeException("Not Authorized");
         }
 
-        UserActivity userActivity = userActivityRepository.findById(userId)
-            .orElseThrow(() -> new RuntimeException("Not Found UserActivity"));
+        UserActivity userActivity = findUserActivityOrThrow(userId);
 
         return userActivityMapper.toUserActivityDto(userActivity);
     }
@@ -154,8 +153,7 @@ public class MongoUserActivityService implements UserActivityService {
     }
 
     public void updateUserNicknameInActivity(User user) {
-        UserActivity userActivity = userActivityRepository.findById(user.getId())
-            .orElseThrow(() -> new RuntimeException("Not Found UserActivity"));
+        UserActivity userActivity = findUserActivityOrThrow(user.getId());
 
         userActivity.updateNickname(user.getNickname());
 

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/service/MongoUserActivityService.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/useractivity/service/MongoUserActivityService.java
@@ -173,6 +173,18 @@ public class MongoUserActivityService implements UserActivityService {
         userActivityRepository.save(userActivity);
     }
 
+    public void updateSubscriptionItemInActivity(Interest interest, List<String> keywords,
+        UUID userId) {
+        UserActivity userActivity = findUserActivityOrThrow(userId);
+
+        userActivity.getSubscriptions().stream()
+            .filter(subscriptionItem -> subscriptionItem.getInterestId().equals(interest.getId()))
+            .findAny()
+            .ifPresent(subscriptionItem -> subscriptionItem.updateInterestKeywords(keywords));
+
+        userActivityRepository.save(userActivity);
+    }
+
     public void updateCommentContentInActivity(Comment comment, UUID userId) {
         UserActivity userActivity = findUserActivityOrThrow(userId);
 

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/useractivity/service/MongoUserActivityServiceTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/useractivity/service/MongoUserActivityServiceTest.java
@@ -3,6 +3,7 @@ package com.codeit.team2.monew.module.domain.useractivity.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -500,6 +501,55 @@ class MongoUserActivityServiceTest {
                 .forEach(
                     savedCommentLikeItem -> assertEquals(newNickname,
                         savedCommentLikeItem.getCommentUserNickname()));
+        }
+    }
+
+    @Nested
+    class updateSubscriptionItemInActivityTest {
+
+        @Test
+        void 관심사_수정_시_SubscriptionItem_수정_성공() {
+            // given
+            User user = TestUserFactory.createWithName("user1");
+            Interest interest = TestEntityFactory.createInterest("AI");
+            Subscription subscription = TestEntityFactory.createSubscription(user, interest);
+
+            UserActivity userActivity = new UserActivity(
+                user.getId(),
+                user.getEmail(),
+                user.getNickname(),
+                user.getCreatedAt(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>()
+            );
+
+            SubscriptionItem subscriptionItem = new SubscriptionItem(
+                subscription.getId(),
+                interest.getId(),
+                interest.getName(),
+                List.of("GPT", "deepsick"),
+                interest.getSubscriberCount(),
+                subscription.getCreatedAt()
+            );
+            userActivity.addSubscriptionItem(subscriptionItem);
+
+            when(userActivityRepository.findById(any())).thenReturn(Optional.of(userActivity));
+
+            // when
+            List<String> newKeywords = List.of("claude", "grock", "gemminai");
+            userActivityService.updateSubscriptionItemInActivity(
+                interest, newKeywords, user.getId());
+
+            // then
+            ArgumentCaptor<UserActivity> captor = ArgumentCaptor.forClass(UserActivity.class);
+            verify(userActivityRepository).save(captor.capture());
+
+            UserActivity saved = captor.getValue();
+
+            saved.getSubscriptions().get(0).getInterestKeywords()
+                .forEach(interestKeywords -> assertTrue(newKeywords.contains(interestKeywords)));
         }
     }
 


### PR DESCRIPTION
## 구현 내용
<!-- 구현한 기능에 대한 간략한 설명을 작성해주세요 -->
- 관심사 수정 시 SubscriptionItem 수정

### 구현된 API 엔드포인트
<!-- 구현한 API 엔드포인트 목록을 작성해주세요 -->
<!-- 예시:
- GET /api/employees - 직원 목록 조회
- POST /api/employees - 직원 등록
- GET /api/employees/{id} - 직원 상세 조회
- PATCH /api/employees/{id} - 직원 정보 수정
- DELETE /api/employees/{id} - 직원 삭제
- GET /api/employees/stats/trend - 직원 수 추이 조회
- GET /api/employees/stats/distribution - 직원 분포 조회
- GET /api/employees/count - 직원 수 조회 -->


### 주요 변경사항
<!-- 주요 변경사항을 작성해주세요 -->
- event, eventlistenr, service, test code 추가

## 테스트 완료 사항
<!-- 테스트한 항목에 체크(x)해주세요 -->
- [x] 단위 테스트
- [ ] 통합 테스트
- [x] API 테스트 (Swagger/Postman 등)
- [ ] 기타 테스트

## 스크린샷
<!-- 필요한 경우 관련 스크린샷을 첨부해주세요 -->

## 체크리스트
<!-- 제출 전 확인해야 할 사항들입니다 -->
- [x] 코딩, 커밋 컨벤션 준수
- [x] 모든 테스트 통과
- [ ] API 명세 준수
- [x] 불필요한 로그, 주석, 미사용 코드 제거

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #137 

## 추가 코멘트 (선택)
<!-- 리뷰어에게 전달할 추가 정보가 있다면 작성해주세요 -->
### 활동 내역 관리 데이터 동기화 문제
- 현재 상태로 MongoDB로 마이그레이션을 하게 된다면 기존 사용자의 활동 내역은 MongoDB에 없기 때문에 아무것도 없는 빈 껍데이 데이터만을 조회하게 됩니다.
- 제가 생각한 방법은 다음과 같습니다. 여러분들의 생각도 공유해주셨으면 좋겠습니다!
1. 조회는 지속적으로 PostgreSQL로 진행
2. 다만 사용자 생성, 댓글 작성 등의 이벤트 발생 시 MongoDB로의 저장도 함께 수행
3. 특정 시간 대에 배치를 이용하여 동기화 작업을 수행
4. 일정 기간을 두고 데이터 정합성에 문제가 없다고 판단되면 MongoDB로 완전히 전환
