### PR TITLE
[Refactor] 댓글 목록 조회 리팩토링, 테스트 코드 추가

### DIFF
--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/controller/docs/CommentControllerDocs.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/controller/docs/CommentControllerDocs.java
@@ -100,7 +100,7 @@ public interface CommentControllerDocs {
     ResponseEntity<Void> hardDelete(UUID commentId);
 
     @Operation(
-        summary = "댓글 물리 삭제",
+        summary = "댓글 목록 조회",
         description = "댓글을 영구적으로 삭제합니다.",
         parameters = {
             @Parameter(name = "Monew-Request-User-ID", description = "요청자 ID", in = ParameterIn.HEADER),

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/repository/CommentCustomRepositoryImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/repository/CommentCustomRepositoryImpl.java
@@ -86,6 +86,7 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository {
 
         List<Comment> result = queryFactory
             .selectFrom(comment)
+            .leftJoin(comment.user).fetchJoin()
             .where(where)
             .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
             .limit(limit + 1)

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/repository/CommentLikeRepository.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/repository/CommentLikeRepository.java
@@ -4,6 +4,7 @@ import com.codeit.team2.monew.module.domain.comment.entity.CommentLike;
 import com.codeit.team2.monew.module.domain.user.entity.User;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -21,4 +22,5 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, UUID> 
     })
     List<CommentLike> findTop10ByUserOrderByLikedAtDesc(User user);
 
+    Set<UUID> findLikedCommentIdsByUserIdAndCommentIds(UUID userId, List<UUID> commentIds);
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/repository/CommentLikeRepository.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/repository/CommentLikeRepository.java
@@ -8,6 +8,8 @@ import java.util.Set;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CommentLikeRepository extends JpaRepository<CommentLike, UUID> {
 
@@ -22,5 +24,8 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, UUID> 
     })
     List<CommentLike> findTop10ByUserOrderByLikedAtDesc(User user);
 
-    Set<UUID> findLikedCommentIdsByUserIdAndCommentIds(UUID userId, List<UUID> commentIds);
+    @Query("SELECT cl.comment.id FROM CommentLike cl WHERE cl.user.id = :userId AND cl.comment.id IN :commentIds")
+    Set<UUID> findLikedCommentIdsByUserIdAndCommentIds(@Param("userId") UUID userId,
+        @Param("commentIds") List<UUID> commentIds);
+
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/repository/CommentRepository.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/repository/CommentRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface CommentRepository extends JpaRepository<Comment, UUID> {
+public interface CommentRepository extends JpaRepository<Comment, UUID>, CommentCustomRepository {
 
     @EntityGraph(attributePaths = {"article"})
     List<Comment> findTop10ByUserOrderByCreatedAtDesc(User user);

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/service/CommentServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/service/CommentServiceImpl.java
@@ -15,7 +15,6 @@ import com.codeit.team2.monew.module.domain.comment.event.CommentUpdateEvent;
 import com.codeit.team2.monew.module.domain.comment.exception.CommentNotFoundException;
 import com.codeit.team2.monew.module.domain.comment.exception.CommentPermissionDeniedException;
 import com.codeit.team2.monew.module.domain.comment.mapper.CommentMapper;
-import com.codeit.team2.monew.module.domain.comment.repository.CommentCustomRepository;
 import com.codeit.team2.monew.module.domain.comment.repository.CommentLikeRepository;
 import com.codeit.team2.monew.module.domain.comment.repository.CommentRepository;
 import com.codeit.team2.monew.module.domain.user.entity.User;
@@ -43,7 +42,6 @@ public class CommentServiceImpl implements CommentService {
     private final ArticleRepository articleRepository;
     private final CommentMapper commentMapper;
     private final CommentRepository commentRepository;
-    private final CommentCustomRepository commentCustomRepository;
     private final CommentLikeRepository commentLikeRepository;
     private final ApplicationEventPublisher publisher;
 
@@ -127,7 +125,7 @@ public class CommentServiceImpl implements CommentService {
     public CursorPageResponseCommentDto findAll(UUID userId,
         CursorPageRequestCommentDto cursorPageRequestCommentDto) {
 
-        Slice<Comment> slices = commentCustomRepository.findAll(
+        Slice<Comment> slices = commentRepository.findAll(
             cursorPageRequestCommentDto.articleId(),
             cursorPageRequestCommentDto.orderBy(),
             cursorPageRequestCommentDto.direction(),

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/service/CommentServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/service/CommentServiceImpl.java
@@ -22,9 +22,10 @@ import com.codeit.team2.monew.module.domain.user.entity.User;
 import com.codeit.team2.monew.module.domain.user.exception.UserNotFoundException;
 import com.codeit.team2.monew.module.domain.user.repository.UserRepository;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -134,12 +135,19 @@ public class CommentServiceImpl implements CommentService {
             cursorPageRequestCommentDto.after(),
             cursorPageRequestCommentDto.limit());
 
-        List<CommentDto> commentDtos = new ArrayList<>();
-        slices.getContent().forEach(comment -> {
-            boolean likedByMe = commentLikeRepository.existsByCommentIdAndUserId(comment.getId(),
-                userId);
-            commentDtos.add(commentMapper.toDto(comment, likedByMe));
-        });
+        List<UUID> commentIds = slices.getContent().stream()
+            .map(Comment::getId)
+            .collect(Collectors.toList());
+
+        Set<UUID> likedCommentIds = commentLikeRepository.findLikedCommentIdsByUserIdAndCommentIds(
+            userId, commentIds);
+
+        List<CommentDto> commentDtos = slices.getContent().stream()
+            .map(comment -> {
+                boolean likedByMe = likedCommentIds.contains(comment.getId());
+                return commentMapper.toDto(comment, likedByMe);
+            })
+            .toList();
 
         Long totalElements = commentRepository.countByArticleId(
             cursorPageRequestCommentDto.articleId());

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/comment/repository/CommentCustomRepositoryImplTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/comment/repository/CommentCustomRepositoryImplTest.java
@@ -1,0 +1,114 @@
+package com.codeit.team2.monew.module.domain.comment.repository;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import com.codeit.team2.monew.config.JpaConfig;
+import com.codeit.team2.monew.config.QuerydslConfig;
+import com.codeit.team2.monew.module.domain.article.entity.Article;
+import com.codeit.team2.monew.module.domain.article.repository.ArticleRepository;
+import com.codeit.team2.monew.module.domain.comment.dto.CommentOrderBy;
+import com.codeit.team2.monew.module.domain.comment.entity.Comment;
+import com.codeit.team2.monew.module.domain.user.entity.User;
+import com.codeit.team2.monew.module.domain.user.repository.UserRepository;
+import java.time.Instant;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import({JpaConfig.class, QuerydslConfig.class})
+@Transactional
+class CommentCustomRepositoryImplTest {
+
+    @Qualifier("commentCustomRepositoryImpl")
+    @Autowired
+    private CommentCustomRepository commentCustomRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    private UUID articleId;
+
+    @BeforeEach
+    void setUp() {
+        User user = userRepository.save(new User("email", "nickname", "password", false));
+        Article article = articleRepository.save(
+            new Article("title", "source", "url", "summary", Set.of(), 0L, Instant.now(), false));
+        articleId = article.getId();
+
+        for (int i = 0; i < 5; i++) {
+            Comment comment = Comment.create(article, user, "content");
+            em.persist(comment);
+        }
+
+        em.flush();
+        em.clear();
+    }
+
+    @Test
+    void testFindAll_orderByCreatedAtAsc() {
+        Slice<Comment> slice = commentCustomRepository.findAll(
+            articleId,
+            CommentOrderBy.createdAt,
+            Direction.ASC,
+            null,
+            null,
+            3
+        );
+
+        assertThat(slice.getContent()).hasSize(3);
+        assertThat(slice.hasNext()).isTrue();
+    }
+
+    @Test
+    void testFindAll_orderByLikeCountDesc_withCursor() {
+        // 첫 페이지 가져오기
+        Slice<Comment> slice = commentCustomRepository.findAll(
+            articleId,
+            CommentOrderBy.likeCount,
+            Direction.DESC,
+            null,
+            null,
+            2
+        );
+
+        assertThat(slice.getContent()).hasSize(2);
+        assertThat(slice.hasNext()).isTrue();
+
+        // 다음 페이지 가져오기 (커서 기반)
+        Comment last = slice.getContent().get(slice.getContent().size() - 1);
+        Long nextCursor = last.getLikeCount();
+        Instant nextAfter = last.getCreatedAt();
+
+        Slice<Comment> nextSlice = commentCustomRepository.findAll(
+            articleId,
+            CommentOrderBy.likeCount,
+            Direction.DESC,
+            nextCursor.toString(),
+            nextAfter,
+            2
+        );
+
+        assertThat(nextSlice.getContent()).isNotEmpty();
+    }
+}

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/comment/service/CommentServiceImplTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/comment/service/CommentServiceImplTest.java
@@ -20,7 +20,6 @@ import com.codeit.team2.monew.module.domain.comment.entity.Comment;
 import com.codeit.team2.monew.module.domain.comment.exception.CommentNotFoundException;
 import com.codeit.team2.monew.module.domain.comment.exception.CommentPermissionDeniedException;
 import com.codeit.team2.monew.module.domain.comment.mapper.CommentMapper;
-import com.codeit.team2.monew.module.domain.comment.repository.CommentCustomRepository;
 import com.codeit.team2.monew.module.domain.comment.repository.CommentLikeRepository;
 import com.codeit.team2.monew.module.domain.comment.repository.CommentRepository;
 import com.codeit.team2.monew.module.domain.user.entity.User;
@@ -58,8 +57,6 @@ class CommentServiceImplTest {
 
     @Mock
     private CommentMapper commentMapper;
-    @Mock
-    private CommentCustomRepository commentCustomRepository;
     @Mock
     private CommentLikeRepository commentLikeRepository;
 
@@ -273,7 +270,7 @@ class CommentServiceImplTest {
             articleId, CommentOrderBy.createdAt, Direction.ASC, null, null, 10);
 
         Slice<Comment> slices = new SliceImpl<>(List.of(comment), PageRequest.of(0, 10), false);
-        when(commentCustomRepository.findAll(cursorPageRequestCommentDto.articleId(),
+        when(commentRepository.findAll(cursorPageRequestCommentDto.articleId(),
             cursorPageRequestCommentDto.orderBy(), cursorPageRequestCommentDto.direction(),
             cursorPageRequestCommentDto.cursor(), cursorPageRequestCommentDto.after(),
             cursorPageRequestCommentDto.limit())).thenReturn(slices);


### PR DESCRIPTION
## 구현 내용
<!-- 구현한 기능에 대한 간략한 설명을 작성해주세요 -->
댓글 목록 조회 리팩토링
레포지토리 테스트 코드 추가

### 구현된 API 엔드포인트
<!-- 구현한 API 엔드포인트 목록을 작성해주세요 -->
<!-- 예시:
- GET /api/employees - 직원 목록 조회
- POST /api/employees - 직원 등록
- GET /api/employees/{id} - 직원 상세 조회
- PATCH /api/employees/{id} - 직원 정보 수정
- DELETE /api/employees/{id} - 직원 삭제
- GET /api/employees/stats/trend - 직원 수 추이 조회
- GET /api/employees/stats/distribution - 직원 분포 조회
- GET /api/employees/count - 직원 수 조회 -->
- GET /api/comments 댓글 목록 조회


### 주요 변경사항
<!-- 주요 변경사항을 작성해주세요 -->
- Dto 매핑 시 N+1 문제 해결
- api 문서 수정
- 테스트 코드 추가

## 테스트 완료 사항
<!-- 테스트한 항목에 체크(x)해주세요 -->
- [x] 단위 테스트
- [ ] 통합 테스트
- [x] API 테스트 (Swagger/Postman 등)
- [ ] 기타 테스트

## 스크린샷
<!-- 필요한 경우 관련 스크린샷을 첨부해주세요 -->

## 체크리스트
<!-- 제출 전 확인해야 할 사항들입니다 -->
- [x] 코딩, 커밋 컨벤션 준수
- [x] 모든 테스트 통과
- [x] API 명세 준수
- [x] 불필요한 로그, 주석, 미사용 코드 제거

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
#100 #163 

## 추가 코멘트 (선택)
<!-- 리뷰어에게 전달할 추가 정보가 있다면 작성해주세요 -->

- 본 목적인 도메인별 페이지네이션 테스트 코드 추가는 아직 완료되지 않았는데 PR 시간이 다가와 한 데까지만 올립니다.
- 스웨거를 보는데 '댓글 목록 조회'가 '댓글 물리 삭제'로 표시되어 수정했습니다.
- Comment -> CommentDto로 매핑 시 두 가지 요소 때문에 N+1 문제가 발생해 해결했습니다.
  -  likedByMe(내가 이 댓글에 좋아요를 눌렀는지): 이 부분은 해당 유저가 좋아요한 commentID를 bulk로 불러와 확인하는 것으로 해결했습니다.
  - User 정보(nickname): CommentMapper에서 ```@Mapping(source = "comment.user.nickname", target = "userNickname")```처럼 user 엔티티에 접근하나 지연 로딩으로 N+1 문제가 발생했습니다. 이를 해결하기 위해 레포지토리에서 User 정보를 fetch join하였습니다.