### PR TITLE
[Refactor] 목록 조회 관련 기능 테스트 커버리지 개선

### DIFF
--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/controller/docs/CommentControllerDocs.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/controller/docs/CommentControllerDocs.java
@@ -101,7 +101,7 @@ public interface CommentControllerDocs {
 
     @Operation(
         summary = "댓글 목록 조회",
-        description = "댓글을 영구적으로 삭제합니다.",
+        description = "조건에 맞는 댓글 목록을 조회합니다.",
         parameters = {
             @Parameter(name = "Monew-Request-User-ID", description = "요청자 ID", in = ParameterIn.HEADER),
             @Parameter(name = "articleId", description = "기사 ID", in = ParameterIn.QUERY),

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/article/repository/ArticleCustomRepositoryImplTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/article/repository/ArticleCustomRepositoryImplTest.java
@@ -1,0 +1,209 @@
+package com.codeit.team2.monew.module.domain.article.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.codeit.team2.monew.config.JpaConfig;
+import com.codeit.team2.monew.config.QuerydslConfig;
+import com.codeit.team2.monew.module.domain.article.dto.request.ArticleOrderBy;
+import com.codeit.team2.monew.module.domain.article.dto.request.CursorPageRequestArticleDto;
+import com.codeit.team2.monew.module.domain.article.entity.Article;
+import com.codeit.team2.monew.module.domain.comment.repository.CommentRepository;
+import com.codeit.team2.monew.module.domain.interest.entity.Interest;
+import com.codeit.team2.monew.module.domain.interest.repository.InterestRepository;
+import com.codeit.team2.monew.module.domain.relation.entity.ArticleInterest;
+import com.codeit.team2.monew.module.domain.user.entity.User;
+import com.codeit.team2.monew.module.domain.user.repository.UserRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@DataJpaTest
+@ActiveProfiles("test-temp")
+@Import({JpaConfig.class, QuerydslConfig.class})
+@Transactional
+class ArticleCustomRepositoryImplTest {
+
+    @Autowired
+    @Qualifier("articleCustomRepositoryImpl")
+    private ArticleCustomRepository articleCustomRepository;
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private InterestRepository interestRepository;
+
+    @Autowired
+    private ArticleInterestRepository articleInterestRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    private UUID interestId;
+
+    @BeforeEach
+    void setUp() {
+        User user = userRepository.save(new User("email", "name", "password", false));
+
+        Interest interest = interestRepository.save(Interest.create("interest"));
+        this.interestId = interest.getId();
+
+        for (int i = 0; i < 10; i++) {
+            Article article = new Article("title " + i, "source", "http://test" + i + ".com",
+                "summary",
+                Set.of(), (long) i, Instant.now(), false);
+            em.persist(article);
+
+            ArticleInterest ai = new ArticleInterest(article, interest);
+            em.persist(ai);
+        }
+    }
+
+    @Test
+    @DisplayName("기사 목록 조회 - 출판일 ASC 정렬")
+    void testFindWithCursor_orderByPublishDateAsc() {
+        CursorPageRequestArticleDto request = new CursorPageRequestArticleDto(null, interestId,
+            null, null, null, ArticleOrderBy.publishDate, Direction.ASC, null, null, 3);
+
+        Slice<Article> slice = articleCustomRepository.findWithCursor(request);
+
+        assertThat(slice.getContent()).hasSize(3);
+        assertThat(slice.hasNext()).isTrue();
+    }
+
+    @Test
+    @DisplayName("기사 목록 조회 - 조회수 DESC 정렬")
+    void testFindWithCursor_orderByViewCountDesc() {
+        CursorPageRequestArticleDto request = new CursorPageRequestArticleDto(
+            null,
+            null,
+            null,
+            null,
+            null,
+            ArticleOrderBy.viewCount,
+            Direction.DESC,
+            null,
+            null,
+            5
+        );
+
+        Slice<Article> slice = articleCustomRepository.findWithCursor(request);
+
+        assertThat(slice.getContent()).hasSize(5);
+        assertThat(slice.hasNext()).isTrue();
+
+        // 조회수가 많은 순으로 정렬되었는지 검증
+        List<Article> articles = slice.getContent();
+        assertThat(articles).isNotEmpty();
+        long previousCount = articles.get(0).getViewCount();
+        for (Article a : articles) {
+            long currentCount = a.getViewCount();
+            assertThat(currentCount).isLessThanOrEqualTo(previousCount);
+            previousCount = currentCount;
+        }
+    }
+
+    @Test
+    @DisplayName("기사 목록 조회 - 댓글수 DESC 정렬")
+    void testFindWithCursor_orderByCommentCountDesc() {
+        CursorPageRequestArticleDto request = new CursorPageRequestArticleDto(
+            null,
+            null,
+            null,
+            null,
+            null,
+            ArticleOrderBy.commentCount,
+            Direction.DESC,
+            null,
+            null,
+            5
+        );
+
+        Slice<Article> slice = articleCustomRepository.findWithCursor(request);
+
+        // 댓글 수가 많은 순으로 정렬되었는지 검증
+        List<Article> articles = slice.getContent();
+        assertThat(articles).isNotEmpty();
+        long previousCommentCount = Long.MAX_VALUE;
+        for (Article article : articles) {
+            long currentCount = commentRepository.countByArticle(article);
+            assertThat(currentCount).isLessThanOrEqualTo(previousCommentCount);
+            previousCommentCount = currentCount;
+        }
+    }
+
+    @Test
+    @DisplayName("기사 목록 조회 - 키워드 필터링")
+    void testFindWithCursor_filterByKeyword() {
+        CursorPageRequestArticleDto request = new CursorPageRequestArticleDto(
+            "1",  // keyword
+            null,
+            null,
+            null,
+            null,
+            ArticleOrderBy.publishDate,
+            Direction.DESC,
+            null,
+            null,
+            10
+        );
+
+        Slice<Article> slice = articleCustomRepository.findWithCursor(request);
+
+        assertThat(slice.getContent())
+            .extracting(Article::getTitle)
+            .allMatch(title -> title.contains("1"));
+    }
+
+    @Test
+    @DisplayName("기사 목록 조회 totalElements 계산 - 키워드 필터링 o")
+    void testCountFilteredTotalElements_withKeywordFilter() {
+        String keyword = "title";
+
+        long count = articleCustomRepository.countFilteredTotalElements(
+            keyword,
+            null,
+            null,
+            null,
+            null
+        );
+
+        assertThat(count).isEqualTo(10); // setUp에선 1개의 Article만 있으므로
+    }
+
+    @Test
+    @DisplayName("기사 목록 조회 totalElements 계산 - 키워드 필터링 x")
+    void testCountFilteredTotalElements_noMatch() {
+        // keyword가 전혀 매칭되지 않는 경우
+        String keyword = "nonexistent";
+
+        long count = articleCustomRepository.countFilteredTotalElements(
+            keyword,
+            null,
+            null,
+            null,
+            null
+        );
+
+        assertThat(count).isEqualTo(0);
+    }
+}

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/comment/repository/CommentCustomRepositoryImplTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/comment/repository/CommentCustomRepositoryImplTest.java
@@ -26,7 +26,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 @DataJpaTest
-@ActiveProfiles("test")
+@ActiveProfiles("test-temp")
 @Import({JpaConfig.class, QuerydslConfig.class})
 @Transactional
 class CommentCustomRepositoryImplTest {

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/comment/repository/CommentCustomRepositoryImplTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/comment/repository/CommentCustomRepositoryImplTest.java
@@ -11,6 +11,8 @@ import com.codeit.team2.monew.module.domain.comment.entity.Comment;
 import com.codeit.team2.monew.module.domain.user.entity.User;
 import com.codeit.team2.monew.module.domain.user.repository.UserRepository;
 import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -110,5 +112,61 @@ class CommentCustomRepositoryImplTest {
         );
 
         assertThat(nextSlice.getContent()).isNotEmpty();
+    }
+
+    @Test
+    void testFindAll_lastPage_hasNextFalse() {
+        // 전체 5개라서 limit=5로 요청하면 마지막 페이지임
+        Slice<Comment> slice = commentCustomRepository.findAll(
+            articleId,
+            CommentOrderBy.createdAt,
+            Direction.ASC,
+            null,
+            null,
+            5
+        );
+
+        assertThat(slice.getContent()).hasSize(5);
+        assertThat(slice.hasNext()).isFalse();
+    }
+
+    @Test
+    void testFindAll_orderByLikeCountAsc_withDifferentLikeCounts() {
+        // 댓글 중 일부의 likeCount를 조작
+        List<Comment> comments = commentRepository.findAll();
+        comments.get(0).incrementLikeCount(); // 1
+        comments.get(1).incrementLikeCount(); // 1
+        comments.get(1).incrementLikeCount(); // 2
+
+        em.flush();
+        em.clear();
+
+        Slice<Comment> slice = commentCustomRepository.findAll(
+            articleId,
+            CommentOrderBy.likeCount,
+            Direction.ASC,
+            null,
+            null,
+            5
+        );
+
+        List<Comment> content = slice.getContent();
+        assertThat(content).isSortedAccordingTo(Comparator.comparing(Comment::getLikeCount));
+    }
+
+    @Test
+    void testFindAll_orderByCreatedAtDesc() {
+        Slice<Comment> slice = commentCustomRepository.findAll(
+            articleId,
+            CommentOrderBy.createdAt,
+            Direction.DESC,
+            null,
+            null,
+            5
+        );
+
+        List<Comment> content = slice.getContent();
+        assertThat(content).isSortedAccordingTo(
+            Comparator.comparing(Comment::getCreatedAt).reversed());
     }
 }

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/interest/controller/InterestControllerTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/interest/controller/InterestControllerTest.java
@@ -1,15 +1,21 @@
 package com.codeit.team2.monew.module.domain.interest.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.codeit.team2.monew.module.domain.interest.exception.InterestErrorCode;
+import com.codeit.team2.monew.module.domain.interest.dto.request.CursorPageRequestInterestDto;
 import com.codeit.team2.monew.module.domain.interest.dto.request.InterestRegisterRequest;
 import com.codeit.team2.monew.module.domain.interest.dto.request.InterestUpdateRequest;
+import com.codeit.team2.monew.module.domain.interest.dto.response.CursorPageResponseInterestDto;
 import com.codeit.team2.monew.module.domain.interest.dto.response.InterestDto;
+import com.codeit.team2.monew.module.domain.interest.exception.InterestErrorCode;
 import com.codeit.team2.monew.module.domain.interest.exception.InterestNotFoundException;
 import com.codeit.team2.monew.module.domain.interest.service.InterestService;
 import com.codeit.team2.monew.module.domain.subscription.dto.SubscriptionDto;
@@ -222,4 +228,38 @@ class InterestControllerTest {
 
     }
 
+    @Test
+    @DisplayName("관심사 목록 조회 API 테스트")
+    void testFindAll() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+
+        List<InterestDto> content = List.of(
+            new InterestDto(UUID.randomUUID(), "테크놀로지", List.of("기술", "개발"), 1L, false),
+            new InterestDto(UUID.randomUUID(), "경제", List.of("주식", "금융"), 1L, false)
+        );
+
+        CursorPageResponseInterestDto responseDto = new CursorPageResponseInterestDto(content, null,
+            null, 10, 2, false);
+
+        when(interestService.findAll(any(), any())).thenReturn(responseDto);
+
+        // when & then
+        mockMvc.perform(get("/api/interests")
+                .header("Monew-Request-User-Id", userId.toString())
+                .param("keyword", "tech")
+                .param("orderBy", "name")
+                .param("direction", "ASC")
+                .param("limit", "10")
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content").isArray())
+            .andExpect(jsonPath("$.content[0].name").value("테크놀로지"))
+            .andExpect(jsonPath("$.hasNext").value(false));
+
+        // verify
+        verify(interestService).findAll(eq(userId),
+            any(CursorPageRequestInterestDto.class));
+    }
 }
+

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/interest/repository/InterestCustomRepositoryTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/interest/repository/InterestCustomRepositoryTest.java
@@ -6,8 +6,11 @@ import com.codeit.team2.monew.config.JpaConfig;
 import com.codeit.team2.monew.config.QuerydslConfig;
 import com.codeit.team2.monew.module.domain.interest.dto.request.InterestOrderBy;
 import com.codeit.team2.monew.module.domain.interest.entity.Interest;
+import com.codeit.team2.monew.module.domain.interest.entity.Keyword;
+import com.codeit.team2.monew.module.domain.user.entity.User;
 import java.time.Instant;
-import java.util.List;
+import java.util.Comparator;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 @DataJpaTest
 @ActiveProfiles("test-temp")
 @Import({JpaConfig.class, QuerydslConfig.class})
+@Transactional
 public class InterestCustomRepositoryTest {
 
 
@@ -39,21 +43,51 @@ public class InterestCustomRepositoryTest {
     @Autowired
     private TestEntityManager em;
 
-    @Transactional
-    @Test
-    @DisplayName("관심사 목록 조회")
-    void testFindAllNameASC() {
-        // given
-        // 관심사 데이터
+    @BeforeEach
+    void setUp() {
+        User user1 = new User("email1", "nickname1", "password", false);
+        User user2 = new User("email2", "nickname2", "password", false);
+        User user3 = new User("email3", "nickname3", "password", false);
+
+        em.persist(user1);
+        em.persist(user2);
+        em.persist(user3);
+
+        // 관심사 생성
         Interest i1 = Interest.create("i1");
         Interest i2 = Interest.create("i2");
         Interest i3 = Interest.create("i3");
+        Interest i4 = Interest.create("i4");
 
-        interestRepository.saveAll(List.of(i1, i2, i3));
+        em.persist(i1);
+        em.persist(i2);
+        em.persist(i3);
+        em.persist(i4);
+
+        // i1: 2명, i2: 3명
+        i1.addSubscriber(user1);
+        i2.addSubscriber(user1);
+        i2.addSubscriber(user2);
+        i3.addSubscriber(user1);
+        i3.addSubscriber(user2);
+        i3.addSubscriber(user3);
+
+        Keyword k1 = new Keyword("alpha");
+        Keyword k2 = new Keyword("beta");
+
+        i1.addKeyword(k1);  // i1 - alpha
+        i2.addKeyword(k2);  // i2 - beta
+
+        em.persist(k1);
+        em.persist(k2);
 
         em.flush();
         em.clear();
+    }
 
+    @Test
+    @DisplayName("관심사 목록 조회 - name ASC")
+    void testFindAllNameASC() {
         String keyword = null;
         InterestOrderBy orderBy = InterestOrderBy.name;
         Direction direction = Direction.ASC;
@@ -61,13 +95,94 @@ public class InterestCustomRepositoryTest {
         Instant after = Instant.now();
         int limit = 2;
 
-        // when
-        Slice<Interest> result = interestCustomRepository.findAll(keyword, orderBy, direction,
-            cursor, after, limit);
+        Slice<Interest> result = interestCustomRepository.findAll(
+            keyword, orderBy, direction, cursor, after, limit
+        );
 
-        // then
         assertThat(result).hasSize(2);
         assertThat(result.hasNext()).isTrue();
-        assertThat(result.getContent().get(0).getName()).isEqualTo("i1");
+        assertThat(result.getContent())
+            .isSortedAccordingTo(Comparator.comparing(Interest::getName));
     }
+
+    @Test
+    @DisplayName("커서 기반 조회 - name ASC")
+    void testFindAllNameASCWithCursor() {
+        // 첫 페이지 가져오기
+        Slice<Interest> slice = interestCustomRepository.findAll(
+            null, InterestOrderBy.name, Direction.ASC, null, null, 2
+        );
+
+        assertThat(slice).hasSize(2);
+        assertThat(slice.hasNext()).isTrue();
+
+        // 다음 페이지 커서 조회
+        String nextCursor = slice.getContent().get(1).getName();
+
+        Slice<Interest> nextSlice = interestCustomRepository.findAll(
+            null, InterestOrderBy.name, Direction.ASC, nextCursor, null, 2
+        );
+
+        assertThat(nextSlice).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("커서 기반 조회 - subscriberCount DESC")
+    void testFindAllSubscriberCountDESCWithCursor() {
+        // 첫 페이지
+        Slice<Interest> slice = interestCustomRepository.findAll(
+            null, InterestOrderBy.subscriberCount, Direction.DESC, null, null, 2
+        );
+
+        assertThat(slice).hasSize(2);
+        assertThat(slice.hasNext()).isTrue();
+
+        // 다음 페이지 커서 조회
+        Interest last = slice.getContent().get(1);
+        String nextCursor = String.valueOf(last.getSubscriberCount());
+        Instant after = last.getCreatedAt();
+
+        Slice<Interest> nextSlice = interestCustomRepository.findAll(
+            null, InterestOrderBy.subscriberCount, Direction.DESC, nextCursor, after, 2
+        );
+
+        assertThat(nextSlice).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("검색 키워드 없이 전체 카운트")
+    void testCountFilteredTotalElements_noKeyword() {
+        long count = interestCustomRepository.countFilteredTotalElements(null, InterestOrderBy.name,
+            Direction.ASC);
+
+        assertThat(count).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("검색 키워드로 필터링된 카운트")
+    void testCountFilteredTotalElements_withKeyword() {
+        long count = interestCustomRepository.countFilteredTotalElements("alpha",
+            InterestOrderBy.name, Direction.ASC);
+
+        assertThat(count).isGreaterThan(0);
+    }
+
+    @Test
+    @DisplayName("검색 키워드 포함 조회 - name ASC")
+    void testFindAllWithKeyword() {
+        String keyword = "i";  // i1, i2 등 포함하는 키워드
+        InterestOrderBy orderBy = InterestOrderBy.name;
+        Direction direction = Direction.ASC;
+        int limit = 10;
+
+        Slice<Interest> result = interestCustomRepository.findAll(
+            keyword, orderBy, direction, null, null, limit
+        );
+
+        assertThat(result).isNotEmpty();
+        assertThat(result.getContent())
+            .allMatch(interest -> interest.getName().toLowerCase().contains("i"));
+    }
+
+
 }


### PR DESCRIPTION
## 구현 내용
<!-- 구현한 기능에 대한 간략한 설명을 작성해주세요 -->

댓글, 기사, 관심사 목록 조회와 관련된
레포지토리의 주요 메소드 테스트와 컨트롤러 테스트를 추가했습니다.

## 테스트 완료 사항
<!-- 테스트한 항목에 체크(x)해주세요 -->
- [x] 단위 테스트
- [ ] 통합 테스트
- [ ] API 테스트 (Swagger/Postman 등)
- [ ] 기타 테스트

## 스크린샷
<!-- 필요한 경우 관련 스크린샷을 첨부해주세요 -->

## 체크리스트
<!-- 제출 전 확인해야 할 사항들입니다 -->
- [x] 코딩, 커밋 컨벤션 준수
- [x] 모든 테스트 통과
- [x] API 명세 준수
- [x] 불필요한 로그, 주석, 미사용 코드 제거

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #163 

## 추가 코멘트 (선택)
<!-- 리뷰어에게 전달할 추가 정보가 있다면 작성해주세요 -->
