### PR TITLE
[Feat] Notification 커스텀 예외 추가

### DIFF
--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/service/ArticleServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/service/ArticleServiceImpl.java
@@ -12,6 +12,7 @@ import com.codeit.team2.monew.module.domain.article.repository.ArticleRepository
 import com.codeit.team2.monew.module.domain.article.repository.ArticleViewRepository;
 import com.codeit.team2.monew.module.domain.comment.repository.CommentRepository;
 import com.codeit.team2.monew.module.domain.user.entity.User;
+import com.codeit.team2.monew.module.domain.user.exception.UserNotFoundException;
 import com.codeit.team2.monew.module.domain.user.repository.UserRepository;
 import java.time.Instant;
 import java.util.List;
@@ -95,6 +96,12 @@ public class ArticleServiceImpl implements ArticleService {
     @Override
     public CursorPageResponseArticleDto findAll(UUID userId,
         CursorPageRequestArticleDto cursorPageRequestArticleDto) {
+
+        if (!userRepository.existsById(userId)) {
+            log.debug("User Not Found - userId: {}", userId);
+            throw new UserNotFoundException(userId);
+        }
+        
         Slice<Article> slices = articleRepository.findWithCursor(cursorPageRequestArticleDto);
 
         List<Article> articles = slices.getContent();

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/service/CommentServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/service/CommentServiceImpl.java
@@ -125,6 +125,11 @@ public class CommentServiceImpl implements CommentService {
     public CursorPageResponseCommentDto findAll(UUID userId,
         CursorPageRequestCommentDto cursorPageRequestCommentDto) {
 
+        if (!userRepository.existsById(userId)) {
+            log.debug("User Not Found - userId: {}", userId);
+            throw new UserNotFoundException(userId);
+        }
+
         Slice<Comment> slices = commentRepository.findAll(
             cursorPageRequestCommentDto.articleId(),
             cursorPageRequestCommentDto.orderBy(),

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/service/InterestServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/service/InterestServiceImpl.java
@@ -160,6 +160,9 @@ public class InterestServiceImpl implements InterestService {
     @Override
     public CursorPageResponseInterestDto findAll(UUID userId,
         CursorPageRequestInterestDto cursorPageRequestInterestDto) {
+
+        getUserOrThrow(userId);
+
         Slice<Interest> slices = interestRepository.findAll(
             cursorPageRequestInterestDto.keyword(), cursorPageRequestInterestDto.orderBy(),
             cursorPageRequestInterestDto.direction(), cursorPageRequestInterestDto.cursor(),

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/exception/NotificationAccessDeniedException.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/exception/NotificationAccessDeniedException.java
@@ -1,0 +1,14 @@
+package com.codeit.team2.monew.module.domain.notification.exception;
+
+import com.codeit.team2.monew.module.common.exception.BaseException;
+import java.util.Map;
+import java.util.UUID;
+
+public class NotificationAccessDeniedException extends BaseException {
+
+    public NotificationAccessDeniedException(UUID userId, UUID notificationId) {
+        super(NotificationErrorCode.NOTIFICATION_ACCESS_DENIED,
+            Map.of("userId", userId, "notificationId", notificationId));
+    }
+}
+

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/exception/NotificationErrorCode.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/exception/NotificationErrorCode.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 public enum NotificationErrorCode implements ErrorCode {
 
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "알림 정보를 찾을 수 없습니다."),
-    NOTIFICATION_ACCESS_DENIED(HttpStatus.BAD_REQUEST, "접근 가능한 알림이 아닙니다.");
+    NOTIFICATION_ACCESS_DENIED(HttpStatus.BAD_REQUEST, "접근 불가능한 알림입니다.");
     private final HttpStatus status;
     private final String message;
 

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/exception/NotificationErrorCode.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/exception/NotificationErrorCode.java
@@ -1,0 +1,27 @@
+package com.codeit.team2.monew.module.domain.notification.exception;
+
+import com.codeit.team2.monew.module.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum NotificationErrorCode implements ErrorCode {
+
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "알림 정보를 찾을 수 없습니다."),
+    NOTIFICATION_ACCESS_DENIED(HttpStatus.BAD_REQUEST, "접근 가능한 알림이 아닙니다.");
+    private final HttpStatus status;
+    private final String message;
+
+    NotificationErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.status;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/exception/NotificationNotFoundException.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/exception/NotificationNotFoundException.java
@@ -1,0 +1,13 @@
+package com.codeit.team2.monew.module.domain.notification.exception;
+
+import com.codeit.team2.monew.module.common.exception.BaseException;
+import java.util.Map;
+import java.util.UUID;
+
+public class NotificationNotFoundException extends BaseException {
+
+    public NotificationNotFoundException(UUID notificationId) {
+        super(NotificationErrorCode.NOTIFICATION_NOT_FOUND,
+            Map.of("notificationId", notificationId));
+    }
+}

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImpl.java
@@ -2,18 +2,22 @@ package com.codeit.team2.monew.module.domain.notification.service;
 
 import com.codeit.team2.monew.module.domain.article.entity.Article;
 import com.codeit.team2.monew.module.domain.comment.entity.Comment;
+import com.codeit.team2.monew.module.domain.comment.exception.CommentNotFoundException;
 import com.codeit.team2.monew.module.domain.comment.repository.CommentRepository;
 import com.codeit.team2.monew.module.domain.interest.entity.Interest;
 import com.codeit.team2.monew.module.domain.notification.dto.CursorPageResponseNotificationDto;
 import com.codeit.team2.monew.module.domain.notification.dto.NotificationDto;
 import com.codeit.team2.monew.module.domain.notification.entity.Notification;
 import com.codeit.team2.monew.module.domain.notification.entity.ResourceType;
+import com.codeit.team2.monew.module.domain.notification.exception.NotificationAccessDeniedException;
+import com.codeit.team2.monew.module.domain.notification.exception.NotificationNotFoundException;
 import com.codeit.team2.monew.module.domain.notification.mapper.NotificationMapper;
 import com.codeit.team2.monew.module.domain.notification.repository.NotificationRepository;
 import com.codeit.team2.monew.module.domain.relation.entity.ArticleInterest;
 import com.codeit.team2.monew.module.domain.subscription.entity.Subscription;
 import com.codeit.team2.monew.module.domain.subscription.repository.SubscriptionRepository;
 import com.codeit.team2.monew.module.domain.user.entity.User;
+import com.codeit.team2.monew.module.domain.user.exception.UserNotFoundException;
 import com.codeit.team2.monew.module.domain.user.repository.UserRepository;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -46,16 +50,16 @@ public class NotificationServiceImpl implements NotificationService {
         if (!commentRepository.existsById(comment.getId())) {
             log.debug("[Notification Creation] Failed: Comment not found - commentId: {}",
                 comment.getId());
-            throw new RuntimeException("Comment not found");
+            throw new CommentNotFoundException(comment.getId());
         }
         if (!userRepository.existsById(author.getId())) {
             log.debug("[Notification Creation] Failed: Author not found - userId: {}",
                 author.getId());
-            throw new RuntimeException("Author not found");
+            throw new UserNotFoundException(author.getId());
         } else if (!userRepository.existsById(liker.getId())) {
             log.debug("[Notification Creation] Failed: Liker not found - userId: {}",
                 liker.getId());
-            throw new RuntimeException("Liker not found");
+            throw new UserNotFoundException(liker.getId());
         }
         String content = liker.getNickname() + "님이 나의 댓글을 좋아합니다.";
         Notification notification = new Notification(author, content, comment.getId(),
@@ -104,21 +108,21 @@ public class NotificationServiceImpl implements NotificationService {
         // 사용자 정보 확인
         if (!userRepository.existsById(userId)) {
             log.debug("[Notification Confirm] Failed: User not found - userId: {}", userId);
-            throw new RuntimeException("User Not Found");
+            throw new UserNotFoundException(userId);
         }
         Notification notification = notificationRepository.findById(notificationId)
             .orElseThrow(() -> {
                 log.debug(
                     "[Notification Confirm] Failed: Notification not found - notificationId: {}",
                     notificationId);
-                return new RuntimeException("Notification Not Found");
+                return new NotificationNotFoundException(notificationId);
             });
 
         if (!notification.getUser().getId().equals(userId)) {
             log.debug(
                 "[Notification Confirm] Failed: User Access Denied - userId: {}, notificationId = {}",
                 userId, notificationId);
-            throw new RuntimeException("User Access Denied");
+            throw new NotificationAccessDeniedException(userId, notificationId);
         }
 
         notification.confirm();
@@ -130,7 +134,7 @@ public class NotificationServiceImpl implements NotificationService {
         // 사용자 정보 확인
         if (!userRepository.existsById(userId)) {
             log.debug("[Notification Confirm] Failed: User not found - userId: {}", userId);
-            throw new RuntimeException("User Not Found");
+            throw new UserNotFoundException(userId);
         }
         notificationRepository.confirmAllByUserId(userId);
     }
@@ -138,6 +142,11 @@ public class NotificationServiceImpl implements NotificationService {
     @Override
     public CursorPageResponseNotificationDto findAll(UUID userId, Instant cursor, Instant after,
         int limit) {
+        // 사용자 정보 확인
+        if (!userRepository.existsById(userId)) {
+            log.debug("[Notification Find] Failed: User not found - userId: {}", userId);
+            throw new UserNotFoundException(userId);
+        }
         // 정렬 조건은 시간 순으로 고정
         Slice<Notification> slices = notificationRepository.findWithCursor(userId, cursor,
             after, limit);

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/article/service/ArticleServiceTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/article/service/ArticleServiceTest.java
@@ -188,6 +188,7 @@ public class ArticleServiceTest {
 
         Slice<Article> slices = new SliceImpl<>(articles);
 
+        when(userRepository.existsById(userId)).thenReturn(true);
         when(articleRepository.findWithCursor(requestDto)).thenReturn(slices);
 
         List<Object[]> commentCounts = List.of(

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/comment/service/CommentServiceImplTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/comment/service/CommentServiceImplTest.java
@@ -2,6 +2,7 @@ package com.codeit.team2.monew.module.domain.comment.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -270,6 +271,8 @@ class CommentServiceImplTest {
             articleId, CommentOrderBy.createdAt, Direction.ASC, null, null, 10);
 
         Slice<Comment> slices = new SliceImpl<>(List.of(comment), PageRequest.of(0, 10), false);
+
+        when(userRepository.existsById(any())).thenReturn(true);
         when(commentRepository.findAll(cursorPageRequestCommentDto.articleId(),
             cursorPageRequestCommentDto.orderBy(), cursorPageRequestCommentDto.direction(),
             cursorPageRequestCommentDto.cursor(), cursorPageRequestCommentDto.after(),

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/interest/service/InterestServiceImplTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/interest/service/InterestServiceImplTest.java
@@ -213,6 +213,8 @@ class InterestServiceImplTest {
 
         Interest interest = TestInterestFactory.create("interest1", List.of("k1", "k2"));
         Slice<Interest> slices = new SliceImpl<>(List.of(interest), PageRequest.of(0, 3), false);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(interestRepository.findAll(cursorPageRequestInterestDto.keyword(),
             cursorPageRequestInterestDto.orderBy(), cursorPageRequestInterestDto.direction(),
             cursorPageRequestInterestDto.cursor(), cursorPageRequestInterestDto.after(),

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImplTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/notification/service/NotificationServiceImplTest.java
@@ -260,6 +260,7 @@ class NotificationServiceImplTest {
         Notification n2 = new Notification(user, "content", UUID.randomUUID(),
             ResourceType.COMMENT);
         Slice<Notification> slices = new SliceImpl<>(List.of(n1, n2), PageRequest.of(0, 5), false);
+        when(userRepository.existsById(userId)).thenReturn(true);
         when(notificationRepository.findWithCursor(any(), any(), any(), anyInt())).thenReturn(
             slices);
         when(notificationRepository.countForPagination(userId)).thenReturn(2L);


### PR DESCRIPTION
## 구현 내용
<!-- 구현한 기능에 대한 간략한 설명을 작성해주세요 -->

Notification 도메인에서 두 가지 커스텀 예외를 추가했습니다.
- NotificationNotFound: 존재하지 않는 알림 정보에 접근하려고 한 경우
- NotificationAccessDenied: 사용자가 자신이 소유하지 않은 알림에 접근하려고 한 경우

### 주요 변경사항
<!-- 주요 변경사항을 작성해주세요 -->
- Notification 커스텀 예외가 추가되었습니다.
- Article, Comment, Interest 서비스의 목록 조회 메소드에서 유저 검증 로직이 추가되었습니다.
- 

## 테스트 완료 사항
<!-- 테스트한 항목에 체크(x)해주세요 -->
- [x] 단위 테스트
- [ ] 통합 테스트
- [ ] API 테스트 (Swagger/Postman 등)
- [ ] 기타 테스트

## 스크린샷
<!-- 필요한 경우 관련 스크린샷을 첨부해주세요 -->

## 체크리스트
<!-- 제출 전 확인해야 할 사항들입니다 -->
- [x] 코딩, 커밋 컨벤션 준수
- [x] 모든 테스트 통과
- [x] API 명세 준수
- [x] 불필요한 로그, 주석, 미사용 코드 제거

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #173 

## 추가 코멘트 (선택)
<!-- 리뷰어에게 전달할 추가 정보가 있다면 작성해주세요 -->

Notification 외에
Article, Comment, Interest ServiceImpl에서
목록 조회 메소드에 사용자 검증 로직을 추가했습니다만,
다들 로그 메시지 형식을 통일해야 할 것 같습니다.