### PR TITLE
task: api 문서 생성 워크플로우 수정

### DIFF
--- a/.github/workflows/generate-openapi.yml
+++ b/.github/workflows/generate-openapi.yml
@@ -117,7 +117,9 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '📄 OpenAPI 문서: ${{ steps.get_version.outputs.version }} 버전 생성 완료.\n\npath: `monew/docs/swagger-${{ steps.get_version.outputs.version }}.json`'
+              body: '📄 OpenAPI 문서: ${{ steps.get_version.outputs.version }} 버전 생성 완료.\n' +
+                    'path: `monew/docs/swagger-${{ steps.get_version.outputs.version }}.json`\n' + 
+                    'Target 브랜치: `${{ github.base_ref }}`'
             })
 
       - name: Comment on PR - Already in PR branch
@@ -130,7 +132,8 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '⚠️ OpenAPI 문서: ${{ steps.get_version.outputs.version }} 버전이 PR 브랜치에 이미 존재하여 새 문서가 생성되지 않음.'
+              body: '⚠️ OpenAPI 문서: ${{ steps.get_version.outputs.version }} 버전이 PR 브랜치에 이미 존재하여 새 문서가 생성되지 않음.\n' +
+                    'PR 브랜치: `${{ github.head_ref }}`'
             })
 
       - name: Comment on PR - Already in target branch
@@ -143,5 +146,6 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '⚠️ OpenAPI 문서: ${{ steps.get_version.outputs.version }} 버전이 타겟 브랜치(${{ github.base_ref }})에 이미 존재하여 새 문서가 생성되지 않음.'
+              body: '⚠️ OpenAPI 문서: ${{ steps.get_version.outputs.version }} 버전이 타겟 브랜치에 이미 존재하여 새 문서가 생성되지 않음.\n' +
+                    'Target 브랜치: `${{ github.base_ref }}`'
             })

--- a/.github/workflows/generate-openapi.yml
+++ b/.github/workflows/generate-openapi.yml
@@ -92,9 +92,16 @@ jobs:
       - name: Commit and push
         if: steps.check_pr.outputs.exists == 'false' && steps.check_target.outputs.exists == 'false'
         run: |
-          cd ./release-branch/monew
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          # release 브랜치 체크아웃
+          git fetch origin ${{ github.base_ref }}
+          git checkout -B ${{ github.base_ref }} origin/${{ github.base_ref }}
+          
+          cp ./pr-branch/monew/docs/swagger-${{ steps.get_version.outputs.version }}.json ./monew/docs/
+          
+          cd ./monew
           git add docs/swagger-${{ steps.get_version.outputs.version }}.json
           git commit -m "chore[bot]: add swagger spec for version ${{ steps.get_version.outputs.version }}"
           git push origin ${{ github.base_ref }}

--- a/.github/workflows/generate-openapi.yml
+++ b/.github/workflows/generate-openapi.yml
@@ -1,7 +1,7 @@
 name: Generate OpenAPI JSON on Release PR
 on:
   pull_request:
-    branches: [ 'release*', 'release-*' , 'task/*' ]
+    branches: [ 'release*', 'release-*' , 'task/**' ]
 
 permissions:
   contents: write

--- a/.github/workflows/generate-openapi.yml
+++ b/.github/workflows/generate-openapi.yml
@@ -1,7 +1,7 @@
 name: Generate OpenAPI JSON on Release PR
 on:
   pull_request:
-    branches: [ 'release*', 'release-*' ]
+    branches: [ 'release*', 'release-*' , 'task/*' ]
 
 permissions:
   contents: write

--- a/.github/workflows/generate-openapi.yml
+++ b/.github/workflows/generate-openapi.yml
@@ -20,11 +20,17 @@ jobs:
       AWS_S3_BUCKET_NAME: dummy
 
     steps:
-      - name: Checkout PR branch
+      - name: Checkout target branch
         uses: actions/checkout@v4
         with:
           ref: ${{ github.base_ref }}
-          path: release-branch
+          path: target-branch
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          path: pr-branch
 
       - name: Set up JDK
         uses: actions/setup-java@v3
@@ -39,14 +45,8 @@ jobs:
           VERSION=$(./gradlew properties --console=plain | grep "^version:" | awk '{print $2}')
           echo "Project version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-        working-directory: ./release-branch/monew
+        working-directory: ./pr-branch/monew
         continue-on-error: false
-
-      - name: Checkout target branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.base_ref }}
-          path: target-branch
 
       - name: Check if swagger file exists in PR branch
         id: check_pr
@@ -58,7 +58,7 @@ jobs:
             echo "✔️ swagger file does not exist in PR branch"
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
-        working-directory: ./release-branch
+        working-directory: ./pr-branch
 
       - name: Check if swagger file exists in target branch
         id: check_target
@@ -75,7 +75,7 @@ jobs:
       - name: Generate OpenAPI docs
         if: steps.check_pr.outputs.exists == 'false' && steps.check_target.outputs.exists == 'false'
         run: ./gradlew generateOpenApiDocs
-        working-directory: ./release-branch/monew
+        working-directory: ./pr-branch/monew
         continue-on-error: false
 
       - name: Copy file to docs/
@@ -87,10 +87,11 @@ jobs:
           cp build/openapi/docs/swagger-${{ steps.get_version.outputs.version }}.json docs/
           echo "➡ 복사 후 docs/ 경로:"
           ls -al docs/
-        working-directory: ./release-branch/monew
+        working-directory: ./pr-branch/monew
 
       - name: Commit and push
         if: steps.check_pr.outputs.exists == 'false' && steps.check_target.outputs.exists == 'false'
+        working-directory: ./target-branch
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -99,7 +100,7 @@ jobs:
           git fetch origin ${{ github.base_ref }}
           git checkout -B ${{ github.base_ref }} origin/${{ github.base_ref }}
           
-          cp ./pr-branch/monew/docs/swagger-${{ steps.get_version.outputs.version }}.json ./monew/docs/
+          cp ../pr-branch/monew/docs/swagger-${{ steps.get_version.outputs.version }}.json ./monew/docs/
           
           cd ./monew
           git add docs/swagger-${{ steps.get_version.outputs.version }}.json

--- a/.github/workflows/generate-openapi.yml
+++ b/.github/workflows/generate-openapi.yml
@@ -41,45 +41,46 @@ jobs:
 
       - name: Get project.version from Gradle (PR branch)
         id: get_version
+        working-directory: ./pr-branch/monew
         run: |
           VERSION=$(./gradlew properties --console=plain | grep "^version:" | awk '{print $2}')
           echo "Project version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-        working-directory: ./pr-branch/monew
         continue-on-error: false
 
       - name: Check if swagger file exists in PR branch
         id: check_pr
+        working-directory: ./pr-branch
         run: |
-          if [ -f "docs/swagger-${{ steps.get_version.outputs.version }}.json" ]; then
+          if [ -f "monew/docs/swagger-${{ steps.get_version.outputs.version }}.json" ]; then
             echo "✔️ swagger file exists in PR branch"
             echo "exists=true" >> $GITHUB_OUTPUT
           else
             echo "✔️ swagger file does not exist in PR branch"
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
-        working-directory: ./pr-branch
 
       - name: Check if swagger file exists in target branch
         id: check_target
+        working-directory: ./target-branch
         run: |
-          if [ -f "docs/swagger-${{ steps.get_version.outputs.version }}.json" ]; then
+          if [ -f "monew/docs/swagger-${{ steps.get_version.outputs.version }}.json" ]; then
             echo "✔️ swagger file exists in target branch"
             echo "exists=true" >> $GITHUB_OUTPUT
           else
             echo "✔️ swagger file does not exist in target branch"
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
-        working-directory: ./target-branch
 
       - name: Generate OpenAPI docs
         if: steps.check_pr.outputs.exists == 'false' && steps.check_target.outputs.exists == 'false'
-        run: ./gradlew generateOpenApiDocs
         working-directory: ./pr-branch/monew
+        run: ./gradlew generateOpenApiDocs
         continue-on-error: false
 
       - name: Copy file to docs/
         if: steps.check_pr.outputs.exists == 'false' && steps.check_target.outputs.exists == 'false'
+        working-directory: ./pr-branch/monew
         run: |
           mkdir -p docs
           echo "➡ build/openapi/docs/ 경로 안 파일들:"
@@ -87,7 +88,6 @@ jobs:
           cp build/openapi/docs/swagger-${{ steps.get_version.outputs.version }}.json docs/
           echo "➡ 복사 후 docs/ 경로:"
           ls -al docs/
-        working-directory: ./pr-branch/monew
 
       - name: Commit and push
         if: steps.check_pr.outputs.exists == 'false' && steps.check_target.outputs.exists == 'false'
@@ -117,8 +117,8 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '📄 OpenAPI 문서: ${{ steps.get_version.outputs.version }} 버전 생성 완료.\n' +
-                    'path: `monew/docs/swagger-${{ steps.get_version.outputs.version }}.json`\n' + 
+              body: '📄 OpenAPI 문서: ${{ steps.get_version.outputs.version }} 버전 생성 완료.\n\n' +
+                    'Path: `monew/docs/swagger-${{ steps.get_version.outputs.version }}.json`\n' + 
                     'Target 브랜치: `${{ github.base_ref }}`'
             })
 
@@ -132,7 +132,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '⚠️ OpenAPI 문서: ${{ steps.get_version.outputs.version }} 버전이 PR 브랜치에 이미 존재하여 새 문서가 생성되지 않음.\n' +
+              body: '⚠️ OpenAPI 문서: ${{ steps.get_version.outputs.version }} 버전이 PR 브랜치에 이미 존재하여 새 문서가 생성되지 않음.\n\n' +
                     'PR 브랜치: `${{ github.head_ref }}`'
             })
 
@@ -146,6 +146,6 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '⚠️ OpenAPI 문서: ${{ steps.get_version.outputs.version }} 버전이 타겟 브랜치에 이미 존재하여 새 문서가 생성되지 않음.\n' +
+              body: '⚠️ OpenAPI 문서: ${{ steps.get_version.outputs.version }} 버전이 타겟 브랜치에 이미 존재하여 새 문서가 생성되지 않음.\n\n' +
                     'Target 브랜치: `${{ github.base_ref }}`'
             })

--- a/.github/workflows/generate-openapi.yml
+++ b/.github/workflows/generate-openapi.yml
@@ -1,7 +1,7 @@
 name: Generate OpenAPI JSON on Release PR
 on:
   pull_request:
-    branches: [ 'release*', 'release-*' , 'task/**' ]
+    branches: [ 'release*', 'release-*' ]
 
 permissions:
   contents: write


### PR DESCRIPTION
## 구현 내용
pr 브랜치에서 문서 생성 후 target 브랜치에만 push 하여 문서를 추가합니다.


### 주요 변경사항
- 문서 생성 워크플로우가 수정되었습니다.

## 테스트 완료 사항
<!-- 테스트한 항목에 체크(x)해주세요 -->
- [ ] 단위 테스트
- [ ] 통합 테스트
- [ ] API 테스트 (Swagger/Postman 등)
- [x] 기타 테스트

## 스크린샷
<!-- 필요한 경우 관련 스크린샷을 첨부해주세요 -->

- target 브랜치에 문서가 생성된 경우
![image](https://github.com/user-attachments/assets/95c7c7f8-ef3f-4399-8982-28502ebc4936)
![image](https://github.com/user-attachments/assets/47257e9e-413c-4115-afd0-582c7c07ea22)

- target 브랜치에 문서가 이미 존재하는 경우
![image](https://github.com/user-attachments/assets/3c6bbd79-1105-4062-8bd6-6647390e3dc7)

## 체크리스트
<!-- 제출 전 확인해야 할 사항들입니다 -->
- [x] 코딩, 커밋 컨벤션 준수
- [x] 모든 테스트 통과
- [x] API 명세 준수
- [x] 불필요한 로그, 주석, 미사용 코드 제거

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #188

## 추가 코멘트 (선택)
<!-- 리뷰어에게 전달할 추가 정보가 있다면 작성해주세요 -->

- 기존 문제 : 초반에 구현한 워크플로우 (develop에서 생성한 브랜치 -> develop)
  테스트 시 `develop에서 생성한 브랜치`에는 push 권한이 열려있었기 때문에 `pr 브랜치`에 문서 생성 및 push에 문제가 없었습니다.
  배포 전 ci 를 할 때에도 `develop` -> `relesase` 로 pr 이 열릴 때, `develop`에서 문서를 생성하고 반영해야 합니다.
  하지만 `develop` 브랜치에 대한 push 권한이 막혀있어 불가능했습니다.

- 해결
1. github action bot에만 develop push 권한 부여 (현재 불가능)
사실 브랜치 설정에서 github action bot에만 push 권한을 열어주면 해결되는 건데요. 
문제는 `Restrict who can push to matching branches` 설정이 조직 레파지토리에만 가능한 설정이어서 보류하였습니다.

2. 생성된 문서를 pr 브랜치가 아닌 target 브랜치로 push
develop에 대한 push 권한 문제이기 때문에 바로 release 에 push 하면 반영하면 됩니다.
- pr 브랜치에서 문서 생성
- target 브랜치에서 checkout 하고 생성된 문서를 바로 push 합니다.

release로 바로 push 하기 때문에 release 브랜치에 변경사항이 없는지 확인해야합니다.
로컬과 원격 브랜치에 정보를 맞추기 위한 코드를 추가했습니다..

<br>

사실 2번으로 해결하였지만 그렇게 좋은 방식은 아닌 것 같습니다.
pr 생성 시 문서 생성을 확인할 수 없고, release에 바로 반영되기 때문이죠..ㅎ
팀 프로젝트 할 때에는 조직 레파지토리로 생성하는 것도 좋을 것 같습니다.

지금 develop에서 테스트를 바로 할 수 없어 임의로 task -> task로 테스트를 진행하였습니다.
ci 시 한 번 더 확인할 것 같습니다 :)