### PR TITLE
feat: 관심사 테스트 커버리지 개선

### DIFF
--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/exception/InterestNotFoundException.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/exception/InterestNotFoundException.java
@@ -7,18 +7,6 @@ import java.util.UUID;
 
 public class InterestNotFoundException extends BaseException {
 
-    public InterestNotFoundException(ErrorCode errorCode) {
-        super(errorCode);
-    }
-
-    public InterestNotFoundException(ErrorCode errorCode, String message) {
-        super(errorCode, message);
-    }
-
-    public InterestNotFoundException(ErrorCode errorCode, Map<String, Object> details) {
-        super(errorCode, details);
-    }
-
     public InterestNotFoundException(UUID id) {
         super(InterestErrorCode.INTEREST_NOT_FOUND, Map.of("id", id));
     }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/service/InterestServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/service/InterestServiceImpl.java
@@ -19,6 +19,7 @@ import com.codeit.team2.monew.module.domain.interest.repository.InterestReposito
 import com.codeit.team2.monew.module.domain.interest.repository.KeywordRepository;
 import com.codeit.team2.monew.module.domain.subscription.repository.SubscriptionRepository;
 import com.codeit.team2.monew.module.domain.user.entity.User;
+import com.codeit.team2.monew.module.domain.user.exception.UserNotFoundException;
 import com.codeit.team2.monew.module.domain.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import java.time.Instant;
@@ -149,7 +150,7 @@ public class InterestServiceImpl implements InterestService {
 
     private User getUserOrThrow(UUID userId) {
         return userRepository.findById(userId).orElseThrow(
-            () -> new RuntimeException("user not found"));
+            () -> new UserNotFoundException(userId));
     }
 
     private Interest getByIdOrThrow(UUID id) {

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/subscription/service/SubscriptionServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/subscription/service/SubscriptionServiceImpl.java
@@ -12,6 +12,7 @@ import com.codeit.team2.monew.module.domain.subscription.exception.SubscriptionN
 import com.codeit.team2.monew.module.domain.subscription.mapper.SubscriptionMapper;
 import com.codeit.team2.monew.module.domain.subscription.repository.SubscriptionRepository;
 import com.codeit.team2.monew.module.domain.user.entity.User;
+import com.codeit.team2.monew.module.domain.user.exception.UserNotFoundException;
 import com.codeit.team2.monew.module.domain.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import java.util.List;
@@ -83,7 +84,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
 
     private User getUserOrThrow(UUID userId) {
         return userRepository.findById(userId).orElseThrow(
-            () -> new IllegalArgumentException("user not found"));
+            () -> new UserNotFoundException(userId));
     }
 
     private Interest getInterestOrThrow(UUID interestId) {

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/interest/controller/InterestControllerTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/interest/controller/InterestControllerTest.java
@@ -36,6 +36,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 @ActiveProfiles("test")
 @WebMvcTest(InterestController.class)
@@ -166,6 +167,22 @@ class InterestControllerTest {
             .andExpect(jsonPath("$.subscribedByMe").value(interestDto.subscribedByMe()));
     }
 
+    @DisplayName("관심사 삭제를 성공하면 204를 응답합니다.")
+    @Test
+    void delete() throws Exception {
+        // given
+        UUID interestId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        // when
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/interests/{interestId}", interestId)
+                .header("Monew-Request-User-Id", userId))
+            .andExpect(status().isNoContent());
+
+        // then
+        verify(interestService).delete(interestId, userId);
+    }
+
     @DisplayName("관심사를 찾을 수 없어 예외를 응답합니다.")
     @Test
     void update_failure() throws Exception {
@@ -195,7 +212,6 @@ class InterestControllerTest {
             .andExpect(jsonPath("$.details").exists())
             .andExpect(jsonPath("$.details.id").value(interestId.toString()));
     }
-
 
 
     @DisplayName("유저가 관심사를 구독합니다.")
@@ -239,7 +255,7 @@ class InterestControllerTest {
         UUID userId = UUID.randomUUID();
 
         // when
-        mockMvc.perform(delete("/api/interests/{interestId}/subscriptions", interestId)
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/interests/{interestId}/subscriptions", interestId)
                 .header("Monew-Request-User-Id", userId))
             .andExpect(status().isNoContent());
 

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/interest/controller/InterestControllerTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/interest/controller/InterestControllerTest.java
@@ -2,11 +2,8 @@ package com.codeit.team2.monew.module.domain.interest.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -255,8 +252,9 @@ class InterestControllerTest {
         UUID userId = UUID.randomUUID();
 
         // when
-        mockMvc.perform(MockMvcRequestBuilders.delete("/api/interests/{interestId}/subscriptions", interestId)
-                .header("Monew-Request-User-Id", userId))
+        mockMvc.perform(
+                MockMvcRequestBuilders.delete("/api/interests/{interestId}/subscriptions", interestId)
+                    .header("Monew-Request-User-Id", userId))
             .andExpect(status().isNoContent());
 
         // then

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/interest/controller/InterestControllerTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/interest/controller/InterestControllerTest.java
@@ -2,8 +2,11 @@ package com.codeit.team2.monew.module.domain.interest.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -15,7 +18,6 @@ import com.codeit.team2.monew.module.domain.interest.dto.request.InterestRegiste
 import com.codeit.team2.monew.module.domain.interest.dto.request.InterestUpdateRequest;
 import com.codeit.team2.monew.module.domain.interest.dto.response.CursorPageResponseInterestDto;
 import com.codeit.team2.monew.module.domain.interest.dto.response.InterestDto;
-import com.codeit.team2.monew.module.domain.interest.exception.InterestErrorCode;
 import com.codeit.team2.monew.module.domain.interest.exception.InterestNotFoundException;
 import com.codeit.team2.monew.module.domain.interest.service.InterestService;
 import com.codeit.team2.monew.module.domain.subscription.dto.SubscriptionDto;
@@ -25,7 +27,6 @@ import com.codeit.team2.monew.module.domain.user.entity.User;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -195,6 +196,9 @@ class InterestControllerTest {
             .andExpect(jsonPath("$.details.id").value(interestId.toString()));
     }
 
+
+
+    @DisplayName("유저가 관심사를 구독합니다.")
     @Test
     void subscription() throws Exception {
         // given
@@ -225,6 +229,22 @@ class InterestControllerTest {
             .andExpect(jsonPath("$.interestKeywords[0]").value(keywords.get(0)))
             .andExpect(jsonPath("$.subscriberCount").value(subscriptionDto.subscriberCount()));
 
+    }
+
+    @DisplayName("구독 취소 성공하여 204를 응답합니다.")
+    @Test
+    void subscriptionCancel() throws Exception {
+        // given
+        UUID interestId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        // when
+        mockMvc.perform(delete("/api/interests/{interestId}/subscriptions", interestId)
+                .header("Monew-Request-User-Id", userId))
+            .andExpect(status().isNoContent());
+
+        // then
+        verify(subscriptionService).cancelSubscription(interestId, userId);
     }
 
     @Test

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/interest/controller/InterestControllerTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/interest/controller/InterestControllerTest.java
@@ -178,8 +178,7 @@ class InterestControllerTest {
         );
 
         when(interestService.update(requestDto, interestId, user.getId()))
-            .thenThrow(new InterestNotFoundException(InterestErrorCode.INTEREST_NOT_FOUND,
-                Map.of("id", interestId)));
+            .thenThrow(new InterestNotFoundException(interestId));
 
         //when & then
         mockMvc.perform(patch("/api/interests/{interestId}", interestId)

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/interest/service/InterestNameSimilarityServiceTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/interest/service/InterestNameSimilarityServiceTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.codeit.team2.monew.module.domain.interest.exception.InvalidSimilarityInputException;
 import org.apache.commons.text.similarity.LevenshteinDistance;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
@@ -14,7 +13,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
-@Disabled
 @SpringBootTest
 @Tag("integration")
 @ActiveProfiles({"test-temp"})

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/interest/service/InterestNameSimilarityServiceTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/interest/service/InterestNameSimilarityServiceTest.java
@@ -15,7 +15,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @Tag("integration")
-@ActiveProfiles({"test-temp"})
+@ActiveProfiles({"test"})
 class InterestNameSimilarityServiceTest {
 
     private static final double DEFAULT_THRESHOLD = 0.8;
@@ -37,7 +37,6 @@ class InterestNameSimilarityServiceTest {
             String word2 = "사과";
 
             double result = interestNameSimilarityService.calculateSimilarity(word1, word2);
-            System.out.println(word1 + " 와 " + word2 + " : " + result);
 
             assertThat(result).isEqualTo(1.0);
         }
@@ -49,7 +48,6 @@ class InterestNameSimilarityServiceTest {
             String word2 = "개발자 공부";
 
             double result = interestNameSimilarityService.calculateSimilarity(word1, word2);
-            System.out.println(word1 + " 와 " + word2 + " : " + result);
 
             assertThat(result).isBetween(0.0, DEFAULT_THRESHOLD);
         }
@@ -61,7 +59,6 @@ class InterestNameSimilarityServiceTest {
             String word2 = "핸드폰케이스";
 
             double result = interestNameSimilarityService.calculateSimilarity(word1, word2);
-            System.out.println(word1 + " 와 " + word2 + " : " + result);
 
             assertThat(result).isBetween(DEFAULT_THRESHOLD, 1.0);
         }
@@ -102,7 +99,6 @@ class InterestNameSimilarityServiceTest {
 
             boolean result = interestNameSimilarityService.isSimilar(word1, word2,
                 DEFAULT_THRESHOLD);
-            System.out.println(word1 + " 와 " + word2 + " : " + result);
 
             assertThat(result).isFalse();
         }

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/interest/service/InterestServiceImplTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/interest/service/InterestServiceImplTest.java
@@ -23,6 +23,7 @@ import com.codeit.team2.monew.module.domain.interest.repository.KeywordRepositor
 import com.codeit.team2.monew.module.domain.subscription.repository.SubscriptionRepository;
 import com.codeit.team2.monew.module.domain.user.TestUserFactory;
 import com.codeit.team2.monew.module.domain.user.entity.User;
+import com.codeit.team2.monew.module.domain.user.exception.UserNotFoundException;
 import com.codeit.team2.monew.module.domain.user.repository.UserRepository;
 import java.util.List;
 import java.util.Optional;
@@ -58,7 +59,6 @@ class InterestServiceImplTest {
 
     @Mock
     private SubscriptionRepository subscriptionRepository;
-
 
     @Mock
     private InterestNameSimilarityService interestNameSimilarityService;
@@ -133,6 +133,24 @@ class InterestServiceImplTest {
             .isInstanceOf(SimilarInterestAlreadyExistsException.class);
     }
 
+    @DisplayName("존재하지 않는 유저인 경우 관심사 생성에 실패한다.")
+    @Test
+    void user_not_exist_create_failure() {
+        // given
+        User user = TestUserFactory.createWithName("name");
+
+        String name = "채소식단";
+        List<String> inputKeywords = List.of("당근", "시금치");
+        InterestRegisterRequest request = new InterestRegisterRequest(name, inputKeywords);
+
+        when(userRepository.findById(any(UUID.class)))
+            .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> interestService.create(request, user.getId()))
+            .isInstanceOf(UserNotFoundException.class);
+    }
+
     @DisplayName("관심사 수정에서 키워드 추가/삭제가 정상적으로 수행된다.")
     @Test
     void update_success() {
@@ -167,14 +185,6 @@ class InterestServiceImplTest {
             .contains("시금치").doesNotContain("당근");
         verify(keywordRepository).delete(any(Keyword.class));
         verify(keywordRepository).save(any(Keyword.class));
-    }
-
-    Interest createInterest(String name, List<String> keywords) {
-        Interest mockInterest = Interest.create(name);
-        for (String keyword : keywords) {
-            mockInterest.addKeyword(new Keyword(keyword));
-        }
-        return mockInterest;
     }
 
     @DisplayName("관심사 삭제가 수행된다.")

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/subscription/service/SubscriptionServiceImplTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/subscription/service/SubscriptionServiceImplTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.codeit.team2.monew.module.domain.interest.TestInterestFactory;
+import com.codeit.team2.monew.module.domain.interest.dto.request.InterestRegisterRequest;
 import com.codeit.team2.monew.module.domain.interest.entity.Interest;
 import com.codeit.team2.monew.module.domain.interest.repository.InterestRepository;
 import com.codeit.team2.monew.module.domain.subscription.TestSubscriptionFactory;
@@ -18,6 +19,7 @@ import com.codeit.team2.monew.module.domain.subscription.mapper.SubscriptionMapp
 import com.codeit.team2.monew.module.domain.subscription.repository.SubscriptionRepository;
 import com.codeit.team2.monew.module.domain.user.TestUserFactory;
 import com.codeit.team2.monew.module.domain.user.entity.User;
+import com.codeit.team2.monew.module.domain.user.exception.UserNotFoundException;
 import com.codeit.team2.monew.module.domain.user.repository.UserRepository;
 import java.util.List;
 import java.util.Optional;
@@ -78,6 +80,21 @@ class SubscriptionServiceImplTest {
         assertThat(result.interestKeywords()).hasSize(2).contains("당근", "시금치");
         assertThat(result.subscriberCount()).isEqualTo(1);
 
+    }
+
+    @DisplayName("존재하지 않는 유저인 경우 관심사 구독에 실패한다.")
+    @Test
+    void user_not_exist_create_failure() {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID interestId = UUID.randomUUID();
+
+        when(userRepository.findById(any(UUID.class)))
+            .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> subscriptionService.subscription(interestId, userId))
+            .isInstanceOf(UserNotFoundException.class);
     }
 
     @DisplayName("유저가 관심사를 이미 구독중인 경우 실패한다.")


### PR DESCRIPTION
## 구현 내용
관심사 관리 테스트 커버리지를 개선하였습니다.

### 구현된 API 엔드포인트
<!-- 구현한 API 엔드포인트 목록을 작성해주세요 -->
해당없음


### 주요 변경사항
<!-- 주요 변경사항을 작성해주세요 -->
- 임시 예외로 되어있던 UserNotFoundException 부분을 수정하였습니다.
- 관심사 구독 취소, 관심사 삭제 controller test 가 추가되었습니다.
- 불필요한 예외 코드를 삭제하였습니다.

## 테스트 완료 사항
<!-- 테스트한 항목에 체크(x)해주세요 -->
- [x] 단위 테스트
- [x] 통합 테스트
- [ ] API 테스트 (Swagger/Postman 등)
- [ ] 기타 테스트

## 체크리스트
<!-- 제출 전 확인해야 할 사항들입니다 -->
- [x] 코딩, 커밋 컨벤션 준수
- [x] 모든 테스트 통과
- [x] API 명세 준수
- [x] 불필요한 로그, 주석, 미사용 코드 제거

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #193

## 추가 코멘트 (선택)
<!-- 리뷰어에게 전달할 추가 정보가 있다면 작성해주세요 -->
