### PR TITLE
[Hotfix]: logging file 경로 변수 추가 - 테스트

### DIFF
--- a/monew/Dockerfile
+++ b/monew/Dockerfile
@@ -16,10 +16,11 @@ ENV PROJECT_NAME=monew
 ARG VERSION=v1.0.0
 ENV PROJECT_VERSION=${VERSION}
 ENV JAVA_OPTS="-Xmx384m -Xms256m -XX:MaxMetaspaceSize=210m -XX:MetaspaceSize=96m -XX:+UseG1GC -XX:+ClassUnloadingWithConcurrentMark -XX:MaxGCPauseMillis=200 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/app/logs/heapdump.hprof"
+ENV LOGGING_FILE_PATH=/var/log/monew
 
 RUN mkdir -p /var/log/monew/archive && chmod 755 /var/log/monew/archive
 
 COPY --from=builder /app/build/libs/${PROJECT_NAME}-${PROJECT_VERSION}.jar app.jar
 EXPOSE 80
 
-ENTRYPOINT ["sh", "-c", "exec java ${JAVA_OPTS} -jar app.jar --server.port=80 --spring.profiles.active=${SPRING_PROFILES_ACTIVE:-prod}"]
+ENTRYPOINT ["sh", "-c", "exec java ${JAVA_OPTS} -Dlogging.file.path=/var/log/monew -jar app.jar --server.port=80 --spring.profiles.active=${SPRING_PROFILES_ACTIVE:-prod}"]


### PR DESCRIPTION
<img width="783" alt="image" src="https://github.com/user-attachments/assets/ddaa2729-e840-4f60-a03b-6fb260a14724" />
Logback은 Spring Boot 설정이 완전히 로드되기 전에 초기화되어, logging.file.path의 값이 Logback에 전달되기 전에 기본값 ./logs가 사용되는 문제 존재