### PR TITLE
[Hotfix]: 로그 관리 시스템 경로 문제 해결

### DIFF
--- a/monew/Dockerfile
+++ b/monew/Dockerfile
@@ -16,10 +16,11 @@ ENV PROJECT_NAME=monew
 ARG VERSION=v1.0.0
 ENV PROJECT_VERSION=${VERSION}
 ENV JAVA_OPTS="-Xmx384m -Xms256m -XX:MaxMetaspaceSize=210m -XX:MetaspaceSize=96m -XX:+UseG1GC -XX:+ClassUnloadingWithConcurrentMark -XX:MaxGCPauseMillis=200 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/app/logs/heapdump.hprof"
+ENV LOGGING_FILE_PATH=/var/log/monew
 
 RUN mkdir -p /var/log/monew/archive && chmod 755 /var/log/monew/archive
 
 COPY --from=builder /app/build/libs/${PROJECT_NAME}-${PROJECT_VERSION}.jar app.jar
 EXPOSE 80
 
-ENTRYPOINT ["sh", "-c", "exec java ${JAVA_OPTS} -jar app.jar --server.port=80 --spring.profiles.active=${SPRING_PROFILES_ACTIVE:-prod}"]
+ENTRYPOINT ["sh", "-c", "exec java ${JAVA_OPTS} -Dlogging.file.path=/var/log/monew -jar app.jar --server.port=80 --spring.profiles.active=${SPRING_PROFILES_ACTIVE:-prod}"]

--- a/monew/Dockerfile
+++ b/monew/Dockerfile
@@ -17,7 +17,7 @@ ARG VERSION=v1.0.0
 ENV PROJECT_VERSION=${VERSION}
 ENV JAVA_OPTS="-Xmx384m -Xms256m -XX:MaxMetaspaceSize=210m -XX:MetaspaceSize=96m -XX:+UseG1GC -XX:+ClassUnloadingWithConcurrentMark -XX:MaxGCPauseMillis=200 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/app/logs/heapdump.hprof"
 
-RUN mkdir -p /app/logs && chmod 755 /app/logs
+RUN mkdir -p /var/log/monew/archive && chmod 755 /var/log/monew/archive
 
 COPY --from=builder /app/build/libs/${PROJECT_NAME}-${PROJECT_VERSION}.jar app.jar
 EXPOSE 80

--- a/monew/src/main/java/com/codeit/team2/monew/module/log/LogUploadService.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/log/LogUploadService.java
@@ -37,9 +37,6 @@ public class LogUploadService {
     @Value("${aws.s3.log-prefix:logs}")
     private String s3LogPrefix;
 
-    @Value("${logging.file.path:./logs}")
-    private String logFilePath;
-
     @Value("${logging.file.archive:${logging.file.path}/archive}")
     private String logArchivePath;
 

--- a/monew/src/main/resources/logback-spring.xml
+++ b/monew/src/main/resources/logback-spring.xml
@@ -18,18 +18,10 @@
     <encoder>
       <pattern>${LOG_PATTERN}</pattern>
     </encoder>
-    <!--    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">-->
-    <!--      <fileNamePattern>${LOG_ARCHIVE}/application.%d{yyyy-MM-dd}.log</fileNamePattern>-->
-    <!--      <maxHistory>14</maxHistory>  &lt;!&ndash; 최대 14일 보관 &ndash;&gt;-->
-    <!--      <totalSizeCap>500MB</totalSizeCap>  &lt;!&ndash; 총 로그 크기 제한 &ndash;&gt;-->
-    <!--    </rollingPolicy>-->
-    <!--  </appender>-->
-    <!-- 테스트용으로 크기 기반 + 시간 기반 혼합 롤링 정책으로 변경 -->
-    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>${LOG_ARCHIVE}/application.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-      <maxFileSize>1KB</maxFileSize> <!-- 매우 작은 크기로 설정하여 강제 롤링 -->
-      <maxHistory>14</maxHistory>
-      <totalSizeCap>500MB</totalSizeCap>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${LOG_ARCHIVE}/application.%d{yyyy-MM-dd}.log</fileNamePattern>
+      <maxHistory>14</maxHistory>  <!-- 최대 14일 보관 -->
+      <totalSizeCap>500MB</totalSizeCap>  <!-- 총 로그 크기 제한 -->
     </rollingPolicy>
   </appender>
 

--- a/monew/src/main/resources/logback-spring.xml
+++ b/monew/src/main/resources/logback-spring.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-  <property name="LOG_PATH" value="${LOG_PATH:-./logs}" />
-  <property name="LOG_ARCHIVE" value="${LOG_ARCHIVE:-${LOG_PATH}/archive}" />
-  <property name="LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%X{requestId}] [%X{clientIp}] - %msg%n" />
+  <property name="LOG_PATH" value="${logging.file.path:-./logs}"/>
+  <property name="LOG_ARCHIVE" value="${logging.file.archive:-${LOG_PATH}/archive}"/>
+  <property name="LOG_PATTERN"
+    value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%X{requestId}] [%X{clientIp}] - %msg%n"/>
 
   <!-- 콘솔 로그 설정 -->
   <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
@@ -17,19 +18,27 @@
     <encoder>
       <pattern>${LOG_PATTERN}</pattern>
     </encoder>
-    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-      <fileNamePattern>${LOG_ARCHIVE}/application.%d{yyyy-MM-dd}.log</fileNamePattern>
-      <maxHistory>14</maxHistory>  <!-- 최대 14일 보관 -->
-      <totalSizeCap>500MB</totalSizeCap>  <!-- 총 로그 크기 제한 -->
+    <!--    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">-->
+    <!--      <fileNamePattern>${LOG_ARCHIVE}/application.%d{yyyy-MM-dd}.log</fileNamePattern>-->
+    <!--      <maxHistory>14</maxHistory>  &lt;!&ndash; 최대 14일 보관 &ndash;&gt;-->
+    <!--      <totalSizeCap>500MB</totalSizeCap>  &lt;!&ndash; 총 로그 크기 제한 &ndash;&gt;-->
+    <!--    </rollingPolicy>-->
+    <!--  </appender>-->
+    <!-- 테스트용으로 크기 기반 + 시간 기반 혼합 롤링 정책으로 변경 -->
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <fileNamePattern>${LOG_ARCHIVE}/application.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <maxFileSize>1KB</maxFileSize> <!-- 매우 작은 크기로 설정하여 강제 롤링 -->
+      <maxHistory>14</maxHistory>
+      <totalSizeCap>500MB</totalSizeCap>
     </rollingPolicy>
   </appender>
 
   <!-- 루트 로거 설정 -->
   <root level="INFO">
-    <appender-ref ref="Console" />
-    <appender-ref ref="RollingFile" />
+    <appender-ref ref="Console"/>
+    <appender-ref ref="RollingFile"/>
   </root>
 
   <!-- 애플리케이션 로거 설정 -->
-  <logger name="com.codeit.team2.monew" level="INFO" />
+  <logger name="com.codeit.team2.monew" level="INFO"/>
 </configuration>


### PR DESCRIPTION
## 문제 상황
 **로그 디렉토리 경로 불일치**: 로그 파일이 의도한 위치(`/var/log/monew/`)가 아닌 `/app/logs/` 디렉토리에 생성됨

이로 인해 S3 백업 기능이 정상적으로 작동하지 않고 있습니다.

## 해결 방안

### 로그 경로 불일치 문제 해결

`Dockerfile`에 시스템 프로퍼티를 추가하여 로그 경로를 명시적으로 지정하였습니다.

```diff
# Dockerfile
FROM openjdk:17-alpine

WORKDIR /app

COPY *.jar app.jar

+ ENV LOGGING_FILE_PATH=/var/log/monew
  
- ENTRYPOINT ["sh", "-c", "exec java ${JAVA_OPTS} -jar app.jar --server.port=80 --spring.profiles.active=${SPRING_PROFILES_ACTIVE:-prod}"]
+ ENTRYPOINT ["sh", "-c", "exec java ${JAVA_OPTS} -Dlogging.file.path=/var/log/monew -jar app.jar --server.port=80 --spring.profiles.active=${SPRING_PROFILES_ACTIVE:-prod}"]

# 로그 디렉토리 생성
RUN mkdir -p /var/log/monew/archive && chmod 755 /var/log/monew/archive
```

## 테스트 방법
### 수정된 코드를 배포 후 아래와 같이 디렉토리 구조를 확인
- 변경 전
<img width="844" alt="Pasted Graphic 23" src="https://github.com/user-attachments/assets/29e0b2b6-afc2-468a-be7c-79e153b7575d" />
- 변경 후
<img width="778" alt="Pasted Graphic 22" src="https://github.com/user-attachments/assets/30582405-b5f3-4454-9a2e-6ecec2558451" />

### 로그 백업 API 테스트
<img width="717" alt="Pasted Graphic 20" src="https://github.com/user-attachments/assets/24635ad0-7fb3-4527-89a2-dc07397a24e0" />
<img width="970" alt="2025-05-08" src="https://github.com/user-attachments/assets/2ee8b6be-92fd-420a-b6a0-f40dd43b1f6b" />

위처럼 올바른 경로에 로그 파일이 생성되고 백업이 동작하는 것을 확인하였습니다.

## 관련 이슈
closes #196 