### PR TITLE
[Hotfix]: logback 롤링 정책 및 시스템, jvm 레벨 타임존 설정 추가

### DIFF
--- a/monew/Dockerfile
+++ b/monew/Dockerfile
@@ -15,12 +15,18 @@ WORKDIR /app
 ENV PROJECT_NAME=monew
 ARG VERSION=v1.0.0
 ENV PROJECT_VERSION=${VERSION}
+ENV TZ=Asia/Seoul
 ENV JAVA_OPTS="-Xmx384m -Xms256m -XX:MaxMetaspaceSize=210m -XX:MetaspaceSize=96m -XX:+UseG1GC -XX:+ClassUnloadingWithConcurrentMark -XX:MaxGCPauseMillis=200 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/app/logs/heapdump.hprof"
 ENV LOGGING_FILE_PATH=/var/log/monew
+
+RUN apk add --no-cache tzdata && \
+    cp /usr/share/zoneinfo/${TZ} /etc/localtime && \
+    echo "${TZ}" > /etc/timezone && \
+    apk del tzdata
 
 RUN mkdir -p /var/log/monew/archive && chmod 755 /var/log/monew/archive
 
 COPY --from=builder /app/build/libs/${PROJECT_NAME}-${PROJECT_VERSION}.jar app.jar
 EXPOSE 80
 
-ENTRYPOINT ["sh", "-c", "exec java ${JAVA_OPTS} -Dlogging.file.path=/var/log/monew -jar app.jar --server.port=80 --spring.profiles.active=${SPRING_PROFILES_ACTIVE:-prod}"]
+ENTRYPOINT ["sh", "-c", "exec java ${JAVA_OPTS} -Duser.timezone=Asia/Seoul -Dlogging.file.path=/var/log/monew -jar app.jar --server.port=80 --spring.profiles.active=${SPRING_PROFILES_ACTIVE:-prod}"]

--- a/monew/src/main/java/com/codeit/team2/monew/module/log/LogUploadScheduler.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/log/LogUploadScheduler.java
@@ -16,9 +16,9 @@ public class LogUploadScheduler {
     private final ZoneId zoneId;
 
     /**
-     * 매일 03:40에 전날 로그 S3에 업로드
+     * 매일 03:30에 전날 로그 S3에 업로드
      */
-    @Scheduled(cron = "0 40 3 * * ?", zone = "#{@timezoneId}")
+    @Scheduled(cron = "0 30 3 * * ?", zone = "#{@timezoneId}")
     public void uploadYesterdayLogs() {
         LocalDate yesterday = LocalDate.now(zoneId).minusDays(1);
         log.info("Starting scheduled log upload for date: {}", yesterday);

--- a/monew/src/main/resources/logback-spring.xml
+++ b/monew/src/main/resources/logback-spring.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+  <springProperty scope="context" name="APP_TIMEZONE" source="app.timezone" defaultValue="Asia/Seoul"/>
   <property name="LOG_PATH" value="${logging.file.path:-./logs}"/>
   <property name="LOG_ARCHIVE" value="${logging.file.archive:-${LOG_PATH}/archive}"/>
   <property name="LOG_PATTERN"
@@ -19,7 +20,7 @@
       <pattern>${LOG_PATTERN}</pattern>
     </encoder>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-      <fileNamePattern>${LOG_ARCHIVE}/application.%d{yyyy-MM-dd}.log</fileNamePattern>
+      <fileNamePattern>${LOG_ARCHIVE}/application.%d{yyyy-MM-dd, ${APP_TIMEZONE}}.log</fileNamePattern>
       <maxHistory>14</maxHistory>  <!-- 최대 14일 보관 -->
       <totalSizeCap>500MB</totalSizeCap>  <!-- 총 로그 크기 제한 -->
     </rollingPolicy>

--- a/monew/src/test/java/com/codeit/team2/monew/module/log/LogUploadSchedulerTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/log/LogUploadSchedulerTest.java
@@ -99,8 +99,8 @@ class LogUploadSchedulerTest {
         Scheduled uploadAnnotation = uploadMethod.getAnnotation(Scheduled.class);
 
         assertNotNull(uploadAnnotation, "uploadYesterdayLogs 메서드에 @Scheduled 어노테이션이 있어야 함");
-        assertEquals("0 40 3 * * ?", uploadAnnotation.cron(),
-            "매일 새벽 3시 40분에 실행되도록 설정되어야 함");
+        assertEquals("0 30 3 * * ?", uploadAnnotation.cron(),
+            "매일 새벽 3시 30분에 실행되도록 설정되어야 함");
 
         Method cleanupMethod = LogUploadScheduler.class.getMethod("cleanupOldLogs");
         Scheduled cleanupAnnotation = cleanupMethod.getAnnotation(Scheduled.class);


### PR DESCRIPTION
## 문제 상황
프로덕션 환경에 배포된 애플리케이션에서 다음과 같은 로그 관련 문제가 발견되었습니다.
### 1. **로그 롤링 타임존 불일치**
컨테이너는 UTC 기준으로 동작하나 애플리케이션은 Asia/Seoul 기준으로 설정되어 있어 날짜 기반 로그 롤링이 예상대로 동작하지 않음
<img width="441" alt="8 193209 UTC 2025" src="https://github.com/user-attachments/assets/3addf0b0-42e9-4279-abfc-58020a2fc7d8" />

### 2. **로그 백업 실패**
타임존 불일치 및 경로 문제로 인해 S3 백업 기능이 정상적으로 작동하지 않음

## 스크린샷
현재 utc 기준으로 자정에 정상적으로 롤링이 된 것을 확인할 수 있었고, api 요청을 통해 s3로 백업을 시도했을 때 로그 백업이 정상적으로 동작하였습니다. 따라서, 타임존 수정만 하면 되는 상황으로 판단했습니다.
<img width="786" alt="image" src="https://github.com/user-attachments/assets/b6f2575f-f232-4ff9-b1ec-06f7f0bf9bdd" />
<img width="718" alt="image" src="https://github.com/user-attachments/assets/e83b1313-9d10-450c-bb2c-03b80c33c605" />
<img width="771" alt="image" src="https://github.com/user-attachments/assets/1bf7d1db-69d6-46a5-8aa0-060e5cd8b68a" />


## 해결 방안
### 1. logback-spring.xml 설정 수정
Spring Boot 설정에서 타임존을 주입받아 로그 롤링에 일관되게 적용
### 2. Dockerfile 수정
컨테이너 OS 레벨과 JVM 레벨에서 타임존을 일관되게 설정
```diff
FROM amazoncorretto:17-alpine AS builder
WORKDIR /app

COPY gradlew .
COPY gradle/ gradle/
COPY build.gradle settings.gradle ./
RUN ./gradlew dependencies --no-daemon

COPY src/ src/
RUN ./gradlew clean build -x test --no-daemon

FROM amazoncorretto:17-alpine
WORKDIR /app

ENV PROJECT_NAME=monew
ARG VERSION=v1.0.0
ENV PROJECT_VERSION=${VERSION}
+ # 타임존 환경 변수 추가
+ ENV TZ=Asia/Seoul
ENV JAVA_OPTS="-Xmx384m -Xms256m -XX:MaxMetaspaceSize=210m -XX:MetaspaceSize=96m -XX:+UseG1GC -XX:+ClassUnloadingWithConcurrentMark -XX:MaxGCPauseMillis=200 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/app/logs/heapdump.hprof"
ENV LOGGING_FILE_PATH=/var/log/monew

+ # Alpine 리눅스에서 타임존 설정 적용
+ RUN apk add --no-cache tzdata && \
+     cp /usr/share/zoneinfo/${TZ} /etc/localtime && \
+     echo "${TZ}" > /etc/timezone && \
+     apk del tzdata

RUN mkdir -p /var/log/monew/archive && chmod 755 /var/log/monew/archive

COPY --from=builder /app/build/libs/${PROJECT_NAME}-${PROJECT_VERSION}.jar app.jar
EXPOSE 80

- ENTRYPOINT ["sh", "-c", "exec java ${JAVA_OPTS} -Dlogging.file.path=/var/log/monew -jar app.jar --server.port=80 --spring.profiles.active=${SPRING_PROFILES_ACTIVE:-prod}"]
+ # JVM 타임존 설정 추가
+ ENTRYPOINT ["sh", "-c", "exec java ${JAVA_OPTS} -Duser.timezone=Asia/Seoul -Dlogging.file.path=/var/log/monew -jar app.jar --server.port=80 --spring.profiles.active=${SPRING_PROFILES_ACTIVE:-prod}"]
```





## 추가 코멘트 (선택)
<!-- 리뷰어에게 전달할 추가 정보가 있다면 작성해주세요 -->
1. 수정된 코드를 배포 후 명령어를 통해 타임존 설정 확인할 예정입니다.
2. 위 수정으로 모든 시간 관련 동작(로그 타임스탬프, 롤링, 백업, 스케줄링)이 일관되게 KST 기준으로 동작할 것으로 기대합니다.