### PR TITLE
[Fix] Query AOP Http 요청에만 빈 생성, dev 프로파일에서만 활성화 #176

### DIFF
--- a/monew/src/main/java/com/codeit/team2/monew/config/queryAspect/ConnectionProxyHandler.java
+++ b/monew/src/main/java/com/codeit/team2/monew/config/queryAspect/ConnectionProxyHandler.java
@@ -4,8 +4,9 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 
-
+@Profile("dev")
 @RequiredArgsConstructor
 public class ConnectionProxyHandler implements InvocationHandler {
 

--- a/monew/src/main/java/com/codeit/team2/monew/config/queryAspect/PreparedStatementProxyHandler.java
+++ b/monew/src/main/java/com/codeit/team2/monew/config/queryAspect/PreparedStatementProxyHandler.java
@@ -5,7 +5,9 @@ import java.lang.reflect.Method;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
 
+@Profile("dev")
 @Slf4j
 @RequiredArgsConstructor
 public class PreparedStatementProxyHandler implements InvocationHandler {

--- a/monew/src/main/java/com/codeit/team2/monew/config/queryAspect/QueryStatistics.java
+++ b/monew/src/main/java/com/codeit/team2/monew/config/queryAspect/QueryStatistics.java
@@ -1,6 +1,7 @@
 package com.codeit.team2.monew.config.queryAspect;
 
 import lombok.Getter;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.annotation.RequestScope;
 
@@ -10,6 +11,7 @@ import org.springframework.web.context.annotation.RequestScope;
 @Component
 @RequestScope
 @Getter
+@Profile("dev")
 public class QueryStatistics {
 
     private String apiUrl;

--- a/monew/src/main/java/com/codeit/team2/monew/config/queryAspect/QueryStatisticsAop.java
+++ b/monew/src/main/java/com/codeit/team2/monew/config/queryAspect/QueryStatisticsAop.java
@@ -22,6 +22,10 @@ public class QueryStatisticsAop {
 
     @Around("execution(* javax.sql.DataSource.getConnection())")
     public Object getConnection(ProceedingJoinPoint joinPoint) throws Throwable {
+        if (RequestContextHolder.getRequestAttributes() == null) {
+            // HTTP 요청이 아닌 경우 AOP를 건너뛰고 원래대로 실행
+            return joinPoint.proceed();
+        }
         Object connection = joinPoint.proceed();
         return Proxy.newProxyInstance(
             connection.getClass().getClassLoader(),


### PR DESCRIPTION
## 구현 내용
<!-- 구현한 기능에 대한 간략한 설명을 작성해주세요 -->

Keyword Cache와 관련하여
HTTP 요청이 아닌 경우에도 쿼리를 측정하려고 하여
애플리케이션이 실행이 실패하는 오류가 있었습니다.

이에 HTTP 요청에만 응하도록 코드를 수정하고
dev 프로파일에서만 클래스들이 활성화되도록 하였습니다.
## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
#176 
