### PR TITLE
feat: 키워드 중복 연결 관련 문제 해결 및 문서 생성 프로필 관련 코드 추가

### DIFF
--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/listener/KeywordCacheListener.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/listener/KeywordCacheListener.java
@@ -3,10 +3,11 @@ package com.codeit.team2.monew.module.domain.article.listener;
 import com.codeit.team2.monew.module.domain.article.batch.rss.KeywordCache;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.stereotype.Component;
 
-
+@Profile("!openapi")
 @Component
 @RequiredArgsConstructor
 public class KeywordCacheListener implements ApplicationListener<ContextRefreshedEvent> {

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/service/InterestServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/interest/service/InterestServiceImpl.java
@@ -24,6 +24,7 @@ import com.codeit.team2.monew.module.domain.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -70,7 +71,8 @@ public class InterestServiceImpl implements InterestService {
 
         Interest interest = Interest.create(interestName);
 
-        for (String keyword : request.keywords()) {
+        Set<String> keywordSet = new HashSet<>(request.keywords());
+        for (String keyword : keywordSet) {
             Keyword getKeyword = keywordRepository.findByName(keyword)
                 .orElseGet(() -> keywordRepository.save(new Keyword(keyword)));
             interest.addKeyword(getKeyword);
@@ -96,7 +98,8 @@ public class InterestServiceImpl implements InterestService {
         Map<String, InterestKeyword> savedKeywords = interest.getKeywords().stream()
             .collect(Collectors.toMap(ik -> ik.getKeyword().getName(), ik -> ik));
 
-        for (String keyword : request.keywords()) {
+        Set<String> keywordSet = new HashSet<>(request.keywords());
+        for (String keyword : keywordSet) {
             if (!savedKeywords.containsKey(keyword)) {
                 Keyword getKeyword = keywordRepository.findByName(keyword)
                     .orElseGet(() -> keywordRepository.save(new Keyword(keyword)));


### PR DESCRIPTION
## 구현 내용
중복 키워드 연결이 불가하도록 로직을 일부 수정했습니다.
+ open api 관련 설정


### 구현된 API 엔드포인트

### 주요 변경사항
<!-- 주요 변경사항을 작성해주세요 -->
- 등록 키워드 중복 연결 제거
요청받은 키워드들 중 중복된 키워드를 제거하는 코드를 추가하였습니다.

- open api 관련 설정이 추가 되었습니다.
KeywordCacheLinstner가 openapi 프로필에서 실행되지 않도록 하였습니다.

## 테스트 완료 사항
<!-- 테스트한 항목에 체크(x)해주세요 -->
- [ ] 단위 테스트
- [ ] 통합 테스트
- [ ] API 테스트 (Swagger/Postman 등)
- [x] 기타 테스트

## 스크린샷
<!-- 필요한 경우 관련 스크린샷을 첨부해주세요 -->

## 체크리스트
<!-- 제출 전 확인해야 할 사항들입니다 -->
- [x] 코딩, 커밋 컨벤션 준수
- [x] 모든 테스트 통과
- [x] API 명세 준수
- [x] 불필요한 로그, 주석, 미사용 코드 제거

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #204

## 추가 코멘트 (선택)
<!-- 리뷰어에게 전달할 추가 정보가 있다면 작성해주세요 -->
