### PR TITLE
[Refactor] t2.micro에서 t3.small로 인스턴스 유형 변경 및 메모리 최적화

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ env:
   ECS_TASK_DEFINITION: .github/workflows/ecs/task-definition.json
   ECS_SERVICE: monew-service
   ECS_CLUSTER: monew-cluster
-  JAVA_OPTS: "-Xmx384m -Xms256m -XX:MaxMetaspaceSize=210m -XX:MetaspaceSize=96m -XX:+UseG1GC -XX:+ClassUnloadingWithConcurrentMark -XX:MaxGCPauseMillis=200 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/app/logs/heapdump.hprof"
+  JAVA_OPTS: "-Xmx1024m -Xms1024m -XX:MaxMetaspaceSize=256m -XX:MetaspaceSize=96m -XX:+UseG1GC -XX:+ClassUnloadingWithConcurrentMark -XX:MaxGCPauseMillis=200 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/app/logs/heapdump.hprof -XX:+UseCompressedOops"
   SPRING_PROFILES_ACTIVE: "prod"
 
 jobs:

--- a/.github/workflows/ecs/task-definition.json
+++ b/.github/workflows/ecs/task-definition.json
@@ -6,15 +6,15 @@
   "requiresCompatibilities": [
     "EC2"
   ],
-  "cpu": "256",
-  "memory": "512",
+  "cpu": "1024",
+  "memory": "2048",
   "containerDefinitions": [
     {
       "name": "monew-app",
       "image": "replace-me",
-      "cpu": 256,
-      "memory": 512,
-      "memoryReservation": 384,
+      "cpu": 1024,
+      "memory": 2048,
+      "memoryReservation": 1536,
       "essential": true,
       "environment": [
         {

--- a/monew/Dockerfile
+++ b/monew/Dockerfile
@@ -16,7 +16,7 @@ ENV PROJECT_NAME=monew
 ARG VERSION=v1.0.0
 ENV PROJECT_VERSION=${VERSION}
 ENV TZ=Asia/Seoul
-ENV JAVA_OPTS="-Xmx384m -Xms256m -XX:MaxMetaspaceSize=210m -XX:MetaspaceSize=96m -XX:+UseG1GC -XX:+ClassUnloadingWithConcurrentMark -XX:MaxGCPauseMillis=200 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/app/logs/heapdump.hprof"
+ENV JAVA_OPTS="-Xmx1024m -Xms1024m -XX:MaxMetaspaceSize=256m -XX:MetaspaceSize=96m -XX:+UseG1GC -XX:+ClassUnloadingWithConcurrentMark -XX:MaxGCPauseMillis=200 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/app/logs/heapdump.hprof -XX:+UseCompressedOops"
 ENV LOGGING_FILE_PATH=/var/log/monew
 
 RUN apk add --no-cache tzdata && \


### PR DESCRIPTION
## 변경 사항

### 1. 작업 정의 업데이트 (.github/workflows/ecs/task-definition.json)
```json
{
  "family": "monew-task",
  "taskRoleArn": "arn:aws:iam::462740558166:role/ecsTaskExecutionRole",
  "executionRoleArn": "arn:aws:iam::462740558166:role/ecsTaskExecutionRole",
  "networkMode": "bridge",
  "requiresCompatibilities": [
    "EC2"
  ],
  "cpu": "1024",
  "memory": "2048",
  "containerDefinitions": [
    {
      "name": "monew-app",
      "image": "replace-me",
      "cpu": 1024,
      "memory": 2048,
      "memoryReservation": 1536,
      "essential": true,
      "environment": [
        {
          "name": "SPRING_PROFILES_ACTIVE",
          "value": "prod"
        }
      ],
```

### 2. 워크플로우 파일 업데이트 (.github/workflows/deploy.yml)
JAVA_OPTS 환경 변수 수정
```yaml
env:
  AWS_REGION: ap-northeast-2
  ECR_REPOSITORY_URI: 462740558166.dkr.ecr.ap-northeast-2.amazonaws.com/team2/monew
  IMAGE_TAG: ${{ github.sha }}
  AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY2 }}
  AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY2 }}
  ECS_TASK_DEFINITION: .github/workflows/ecs/task-definition.json
  ECS_SERVICE: monew-service
  ECS_CLUSTER: monew-cluster
  JAVA_OPTS: "-Xmx1024m -Xms1024m -XX:MaxMetaspaceSize=256m -XX:MetaspaceSize=96m -XX:+UseG1GC -XX:+ClassUnloadingWithConcurrentMark -XX:MaxGCPauseMillis=200 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/app/logs/heapdump.hprof -XX:+UseCompressedOops"
  SPRING_PROFILES_ACTIVE: "prod"
```
### 3. Dockerfile 업데이트 (monew/Dockerfile)
JAVA_OPTS 환경 변수 수정
```dockerfile
ENV JAVA_OPTS="-Xmx1024m -Xms1024m -XX:MaxMetaspaceSize=256m -XX:MetaspaceSize=96m -XX:+UseG1GC -XX:+ClassUnloadingWithConcurrentMark -XX:MaxGCPauseMillis=200 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/app/logs/heapdump.hprof -XX:+UseCompressedOops"
```

## 변경 이유
- t2.micro(1GB 메모리, 1 vCPU) → t3.small(2GB 메모리, 2 vCPU)로 인스턴스 유형 변경
- 메모리 사용량이 t2.micro에서 약 75%로 높게 유지되고 있어 성능 문제 가능성 존재
- 메모리 제한을 512MB에서 2048MB로 증가시켜 애플리케이션 성능 개선
- JVM 힙 메모리를 384MB에서 1024MB로 증가시켜 GC 부하 감소 및 성능 향상
- -XX:+UseCompressedOops 옵션 추가로 64비트 JVM에서 메모리 사용 효율성 향상

## 테스트
- AWS 콘솔에서 Launch Template 업데이트를 완료한 상태입니다. (t2.micro → t3.small)
- PR 머지 후 release 브랜치로 머지
- GitHub Actions 워크플로우 실행 확인
- 배포 후 CloudWatch에서 메모리 사용률 모니터링(메모리 사용률 50%이하로 감소 기대)
- 애플리케이션 응답 시간 및 안정성 개선 확인

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #209 
