### PR TITLE
[Hotfix] 메모리 설정 최적화

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ env:
   ECS_TASK_DEFINITION: .github/workflows/ecs/task-definition.json
   ECS_SERVICE: monew-service
   ECS_CLUSTER: monew-cluster
-  JAVA_OPTS: "-Xmx1024m -Xms1024m -XX:MaxMetaspaceSize=256m -XX:MetaspaceSize=96m -XX:+UseG1GC -XX:+ClassUnloadingWithConcurrentMark -XX:MaxGCPauseMillis=200 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/app/logs/heapdump.hprof -XX:+UseCompressedOops"
+  JAVA_OPTS: "-Xmx768m -Xms512m -XX:MaxMetaspaceSize=256m -XX:MetaspaceSize=96m -XX:+UseG1GC -XX:+ClassUnloadingWithConcurrentMark -XX:MaxGCPauseMillis=200 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/app/logs/heapdump.hprof -XX:+UseCompressedOops -XX:+ExitOnOutOfMemoryError"
   SPRING_PROFILES_ACTIVE: "prod"
 
 jobs:

--- a/.github/workflows/ecs/task-definition.json
+++ b/.github/workflows/ecs/task-definition.json
@@ -7,14 +7,14 @@
     "EC2"
   ],
   "cpu": "1024",
-  "memory": "2048",
+  "memory": "1792",
   "containerDefinitions": [
     {
       "name": "monew-app",
       "image": "replace-me",
       "cpu": 1024,
-      "memory": 2048,
-      "memoryReservation": 1536,
+      "memory": 1536,
+      "memoryReservation": 1024,
       "essential": true,
       "environment": [
         {

--- a/monew/Dockerfile
+++ b/monew/Dockerfile
@@ -16,7 +16,7 @@ ENV PROJECT_NAME=monew
 ARG VERSION=v1.0.0
 ENV PROJECT_VERSION=${VERSION}
 ENV TZ=Asia/Seoul
-ENV JAVA_OPTS="-Xmx1024m -Xms1024m -XX:MaxMetaspaceSize=256m -XX:MetaspaceSize=96m -XX:+UseG1GC -XX:+ClassUnloadingWithConcurrentMark -XX:MaxGCPauseMillis=200 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/app/logs/heapdump.hprof -XX:+UseCompressedOops"
+JAVA_OPTS="-Xmx768m -Xms512m -XX:MaxMetaspaceSize=256m -XX:MetaspaceSize=96m -XX:+UseG1GC -XX:+ClassUnloadingWithConcurrentMark -XX:MaxGCPauseMillis=200 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/app/logs/heapdump.hprof -XX:+UseCompressedOops -XX:+ExitOnOutOfMemoryError"
 ENV LOGGING_FILE_PATH=/var/log/monew
 
 RUN apk add --no-cache tzdata && \


### PR DESCRIPTION
### 이슈 및 변경사항
#### 1. OOM 문제
- Exit code 137 오류(SIGKILL로 인한 강제 종료)가 메모리 부족으로 발생
- 현재 설정에서는 컨테이너가 필요한 메모리보다 많은 메모리를 요구함

#### 2. 메모리 설정 최적화
- 총 작업 메모리를 1792MB로 설정하여 OS 및 ECS 에이전트를 위한 여유 공간 확보
- JVM 힙 메모리를 768MB로 줄이고, 초기 힙을 512MB로 설정하여 점진적 메모리 할당

#### 3. 안정성 개선
- -XX:+ExitOnOutOfMemoryError 추가: OOM 발생 시 좀비 프로세스 방지 및 빠른 복구

## 추가 코멘트 (선택)
<!-- 리뷰어에게 전달할 추가 정보가 있다면 작성해주세요 -->
배포후 다시 점검해보겠습니다.