### PR TITLE
fix: admin jar 파일 이름 수정 #191

### DIFF
--- a/monew/admin/build.gradle
+++ b/monew/admin/build.gradle
@@ -9,6 +9,11 @@ jar {
     archiveVersion.set('v1.0.0')
 }
 
+bootJar {
+    archiveBaseName.set('monew-admin')
+    archiveVersion.set('v1.0.0')
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'de.codecentric:spring-boot-admin-starter-server:3.4.5'


### PR DESCRIPTION
## 구현 내용
<!-- 구현한 기능에 대한 간략한 설명을 작성해주세요 -->

```
Dockerfile:29
--------------------
  27 |     RUN mkdir -p /var/log/admin/archive && chmod 755 /var/log/admin/archive
  28 |     
  29 | >>> COPY --from=builder /app/admin/build/libs/${PROJECT_NAME}-${PROJECT_VERSION}.jar app.jar
  30 |     EXPOSE 90
  31 |     
--------------------
ERROR: failed to solve: failed to compute cache key: failed to calculate checksum of ref 5a5ab3d3-15e7-4071-8538-de86d6c8ad50::etgyookorev8e8uucnfiy1cbz: "/app/admin/build/libs/monew-admin-v1.0.0.jar": not found
```

해당 jar 파일을 못 찾는 문제로
bootJar이 다른 이름으로 생성되고 있었음
build.gradle에서 bootJar 이름 지정

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #191 

## 추가 코멘트 (선택)
<!-- 리뷰어에게 전달할 추가 정보가 있다면 작성해주세요 -->
