### PR TITLE
[Fix] monew 클라이언트의 admin url 변경

### DIFF
--- a/monew/src/main/resources/application-prod.yaml
+++ b/monew/src/main/resources/application-prod.yaml
@@ -33,7 +33,7 @@ spring:
   boot:
     admin:
       client:
-        url: http://monew-admin-app:90
+        url: http://172.31.27.197:90
     hikari:
       maximum-pool-size: 20       # 기본 10에서 증가
       minimum-idle: 5             # 유휴 연결 수 유지


### PR DESCRIPTION
## 구현 내용
<!-- 구현한 기능에 대한 간략한 설명을 작성해주세요 -->
컨테이너 실행은 되지만
Spring Boot Admin 서버에 monew app이 클라이언트로 등록되지 않아 인스턴스를 관찰할 수 없었음
이에 따라 한 태스크 내에 컨테이너끼리 서로 접근하려면 태스크의 프라이빗 IP 주소를 활용하면 된다고 해서
url을 변경함

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #이슈번호

## 추가 코멘트 (선택)
<!-- 리뷰어에게 전달할 추가 정보가 있다면 작성해주세요 -->
