### PR TITLE
[Fix] Spring Boot Admin client 연결 변경

### DIFF
--- a/monew/src/main/resources/application-prod.yaml
+++ b/monew/src/main/resources/application-prod.yaml
@@ -34,6 +34,8 @@ spring:
     admin:
       client:
         url: http://172.31.27.197:90
+        instance:
+          prefer-ip-address: true
     hikari:
       maximum-pool-size: 20       # 기본 10에서 증가
       minimum-idle: 5             # 유휴 연결 수 유지


### PR DESCRIPTION
## 구현 내용
<!-- 구현한 기능에 대한 간략한 설명을 작성해주세요 -->
- 문제
- admin 로그를 보니 client에 health 등 특정 체크들을 보낼 때 IP가 아니라 인스턴스 ID로 보내고 있음. 네트워크가 bridge 모드인 경우에는 IP 주소로 접근해야 하므로 prefer-ip-address 옵션 추가
```
025-05-09T21:13:18.405+09:00  INFO 1 --- [admin] [or-http-epoll-1] d.c.b.a.server.services.StatusUpdater    : Couldn't retrieve status for Instance(id=cb3841f22375, version=0, registration=Registration(name=monew, managementUrl=http://b618e8a88d14:80/actuator, healthUrl=http://b618e8a88d14:80/actuator/health, serviceUrl=http://b618e8a88d14:80/, source=http-api), registered=true, statusInfo=StatusInfo(status=UNKNOWN, details={}), statusTimestamp=2025-05-09T12:13:17.018893106Z, info=Info(values={}), endpoints=Endpoints(endpoints={health=Endpoint(id=health, url=http://b618e8a88d14:80/actuator/health)}), buildVersion=null, tags=Tags(values={}))
```
- 해결:  Admin 서버가 컨테이너 이름(b618e8a88d14)이 아니라 등록할 때 사용한 IP 기반 주소로 health 엔드포인트를 확인

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #이슈번호

## 추가 코멘트 (선택)
<!-- 리뷰어에게 전달할 추가 정보가 있다면 작성해주세요 -->
