### PR TITLE
feat: 기사 출처 목록 조회 api 구현

### DIFF
--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/controller/ArticleController.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/controller/ArticleController.java
@@ -4,9 +4,12 @@ package com.codeit.team2.monew.module.domain.article.controller;
 import com.codeit.team2.monew.module.domain.article.controller.docs.ArticleControllerDocs;
 import com.codeit.team2.monew.module.domain.article.dto.ArticleViewDto;
 import com.codeit.team2.monew.module.domain.article.dto.CursorPageResponseArticleDto;
+import com.codeit.team2.monew.module.domain.article.dto.request.ArticleSourceIn;
 import com.codeit.team2.monew.module.domain.article.dto.request.CursorPageRequestArticleDto;
 import com.codeit.team2.monew.module.domain.article.service.ArticleService;
 import jakarta.validation.Valid;
+import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -57,6 +60,14 @@ public class ArticleController implements ArticleControllerDocs {
             cursorPageRequestArticleDto);
         log.info("Complete - ArticleController/findAll");
         return ResponseEntity.ok().body(result);
+    }
+
+    @GetMapping("/sources")
+    public ResponseEntity<List<ArticleSourceIn>> getSources() {
+        log.info("Start - ArticleController/getSources");
+        List<ArticleSourceIn> sources = Arrays.stream(ArticleSourceIn.values()).toList();
+        log.info("Complete - ArticleController/getSources");
+        return ResponseEntity.ok().body(sources);
     }
 
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/controller/docs/ArticleControllerDocs.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/controller/docs/ArticleControllerDocs.java
@@ -4,15 +4,18 @@ import com.codeit.team2.monew.config.SwaggerTags.Descriptions;
 import com.codeit.team2.monew.config.SwaggerTags.Tags;
 import com.codeit.team2.monew.module.domain.article.dto.ArticleViewDto;
 import com.codeit.team2.monew.module.domain.article.dto.CursorPageResponseArticleDto;
+import com.codeit.team2.monew.module.domain.article.dto.request.ArticleSourceIn;
 import com.codeit.team2.monew.module.domain.article.dto.request.CursorPageRequestArticleDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import java.util.UUID;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
@@ -90,4 +93,15 @@ public interface ArticleControllerDocs {
         UUID userId,
         @ParameterObject CursorPageRequestArticleDto cursorPageRequestArticleDto
     );
+
+    @Operation(
+        summary = "출처 목록 조회",
+        description = "출처 목록을 조회합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    @GetMapping("/sources")
+    ResponseEntity<List<ArticleSourceIn>> getSources();
 }

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/article/dto/request/ArticleSourceIn.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/article/dto/request/ArticleSourceIn.java
@@ -1,5 +1,8 @@
 package com.codeit.team2.monew.module.domain.article.dto.request;
 
 public enum ArticleSourceIn {
-    NAVER
+    NAVER,
+    CHOSUN,
+    HANKYUNG,
+    YONHAP
 }

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/article/controller/ArticleControllerTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/article/controller/ArticleControllerTest.java
@@ -118,4 +118,17 @@ public class ArticleControllerTest {
             .andExpect(jsonPath("$.size").value(1))
             .andExpect(jsonPath("$.hasNext").value(false));
     }
+
+    @Test
+    void getSources_success() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+
+        // when & then
+        mockMvc.perform(get("/api/articles/sources")
+                .header("Monew-Request-User-Id", userId.toString())
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.length()").value(4));
+    }
 }


### PR DESCRIPTION
## 구현 내용
기사 출처 목록 조회 api 를 구현합니다.
현재 조회가 가능한 기사 출처 목록을 가져옵니다.

### 구현된 API 엔드포인트
<!-- 구현한 API 엔드포인트 목록을 작성해주세요 -->
GET /api/articles/sources


### 주요 변경사항
<!-- 주요 변경사항을 작성해주세요 -->
- ArticleController 에 getSources가 추가되었습니다.
- ArticleControllerDocs에 getSources 관련 문서가 추가되었습니다.
- ArticleControllerTest에 getSources_success 테스트가 추가 되었습니다.

## 테스트 완료 사항
<!-- 테스트한 항목에 체크(x)해주세요 -->
- [x] 단위 테스트
- [ ] 통합 테스트
- [x] API 테스트 (Swagger/Postman 등)
- [x] 기타 테스트

## 스크린샷
![image](https://github.com/user-attachments/assets/f19dc751-90f4-4226-8f86-34e9b1b80c9b)


## 체크리스트
<!-- 제출 전 확인해야 할 사항들입니다 -->
- [x] 코딩, 커밋 컨벤션 준수
- [x] 모든 테스트 통과
- [x] API 명세 준수
- [x] 불필요한 로그, 주석, 미사용 코드 제거

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #254

## 추가 코멘트 (선택)
<!-- 리뷰어에게 전달할 추가 정보가 있다면 작성해주세요 -->
article이 지웅님 도메인이신데, 간단하기도 하고 문서가 추가가 필요해 제가 진행하였습니다!
확인 부탁드립니다:)
