### PR TITLE
[Hotfix]: 댓글 논리 삭제 여부 체크 로직 추가

### DIFF
--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/repository/CommentRepository.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/repository/CommentRepository.java
@@ -4,6 +4,7 @@ import com.codeit.team2.monew.module.domain.article.entity.Article;
 import com.codeit.team2.monew.module.domain.comment.entity.Comment;
 import com.codeit.team2.monew.module.domain.user.entity.User;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,11 +16,14 @@ public interface CommentRepository extends JpaRepository<Comment, UUID>, Comment
     @EntityGraph(attributePaths = {"article"})
     List<Comment> findTop10ByUserOrderByCreatedAtDesc(User user);
 
+    Optional<Comment> findByIdAndDeletedFalse(UUID commentId);
+
     Long countByArticle(Article article);
 
-    Long countByArticleId(UUID articleId);
+    @Query("SELECT COUNT(c) FROM Comment c WHERE c.article.id = :articleId AND c.deleted = false")
+    Long countByArticleId(@Param("articleId") UUID articleId);
 
-    @Query("SELECT c.article.id, COUNT(c) FROM Comment c WHERE c.article.id IN :articleIds GROUP BY c.article.id")
+    @Query("SELECT c.article.id, COUNT(c) FROM Comment c WHERE c.article.id IN :articleIds AND c.deleted = false GROUP BY c.article.id")
     List<Object[]> countByArticleIds(@Param("articleIds") List<UUID> articleIds);
 
 

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/service/CommentLikeServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/service/CommentLikeServiceImpl.java
@@ -13,7 +13,6 @@ import com.codeit.team2.monew.module.domain.notification.service.NotificationSer
 import com.codeit.team2.monew.module.domain.user.entity.User;
 import com.codeit.team2.monew.module.domain.user.exception.UserNotFoundException;
 import com.codeit.team2.monew.module.domain.user.repository.UserRepository;
-import jakarta.persistence.EntityNotFoundException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,9 +34,9 @@ public class CommentLikeServiceImpl implements CommentLikeService {
 
     @Override
     public CommentLike like(UUID commentId, UUID userId) {
-        Comment comment = commentRepository.findById(commentId)
+        Comment comment = commentRepository.findByIdAndDeletedFalse(commentId)
             .orElseThrow(() -> {
-                log.debug("Comment Not Found: commentId={}", commentId);
+                log.debug("Comment Not Found or Deleted: commentId={}", commentId);
                 return new CommentNotFoundException(commentId);
             });
 
@@ -75,6 +74,12 @@ public class CommentLikeServiceImpl implements CommentLikeService {
             });
 
         Comment comment = commentLike.getComment();
+
+        if (comment.isDeleted()) {
+            log.debug("Comment is deleted - cannot unlike: commentId={}", commentId);
+            throw new CommentNotFoundException(commentId);
+        }
+
         comment.decrementLikeCount();
 
         // 댓글 좋아요 취소 이벤트 발생

--- a/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/service/CommentServiceImpl.java
+++ b/monew/src/main/java/com/codeit/team2/monew/module/domain/comment/service/CommentServiceImpl.java
@@ -68,9 +68,9 @@ public class CommentServiceImpl implements CommentService {
 
     @Override
     public CommentDto edit(UUID commentId, UUID userId, CommentUpdateRequest request) {
-        Comment comment = commentRepository.findById(commentId)
+        Comment comment = commentRepository.findByIdAndDeletedFalse(commentId)
             .orElseThrow(() -> {
-                log.debug("Comment Not Found - commentId: {}", commentId);
+                log.debug("Comment Not Found or Deleted - commentId: {}", commentId);
                 return new CommentNotFoundException(commentId);
             });
 
@@ -95,9 +95,9 @@ public class CommentServiceImpl implements CommentService {
 
     @Override
     public void delete(UUID commentId, UUID userId) {
-        Comment comment = commentRepository.findById(commentId)
+        Comment comment = commentRepository.findByIdAndDeletedFalse(commentId)
             .orElseThrow(() -> {
-                log.debug("Comment Not Found - commentId: {}", commentId);
+                log.debug("Comment Not Found or Deleted - commentId: {}", commentId);
                 return new CommentNotFoundException(commentId);
             });
 

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/comment/service/CommentLikeServiceImplTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/comment/service/CommentLikeServiceImplTest.java
@@ -70,7 +70,7 @@ class CommentLikeServiceImplTest {
     @Test
     @DisplayName("댓글 종아요 - 성공")
     void like_Success() {
-        when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
+        when(commentRepository.findByIdAndDeletedFalse(commentId)).thenReturn(Optional.of(comment));
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(commentLikeRepository.existsByCommentIdAndUserId(commentId, userId)).thenReturn(false);
         when(commentLikeRepository.save(any(CommentLike.class))).thenReturn(commentLike);
@@ -79,7 +79,7 @@ class CommentLikeServiceImplTest {
         CommentLike result = commentLikeService.like(commentId, userId);
 
         assertThat(result).isEqualTo(commentLike);
-        verify(commentRepository).findById(commentId);
+        verify(commentRepository).findByIdAndDeletedFalse(commentId);
         verify(userRepository).findById(userId);
         verify(commentLikeRepository).existsByCommentIdAndUserId(commentId, userId);
         verify(commentLikeRepository).save(any(CommentLike.class));
@@ -89,7 +89,7 @@ class CommentLikeServiceImplTest {
     @Test
     @DisplayName("댓글 종아요 - 실패: 댓글 없음")
     void like_CommentNotFound() {
-        when(commentRepository.findById(commentId)).thenReturn(Optional.empty());
+        when(commentRepository.findByIdAndDeletedFalse(commentId)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> commentLikeService.like(commentId, userId))
             .isInstanceOf(CommentNotFoundException.class)
@@ -99,7 +99,7 @@ class CommentLikeServiceImplTest {
     @Test
     @DisplayName("댓글 종아요 - 실패: 사용자 없음")
     void like_UserNotFoound() {
-        when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
+        when(commentRepository.findByIdAndDeletedFalse(commentId)).thenReturn(Optional.of(comment));
         when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> commentLikeService.like(commentId, userId))
@@ -110,7 +110,7 @@ class CommentLikeServiceImplTest {
     @Test
     @DisplayName("댓글 종아요 - 실패: 이미 좋아요 누름")
     void like_AlreadyLiked() {
-        when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
+        when(commentRepository.findByIdAndDeletedFalse(commentId)).thenReturn(Optional.of(comment));
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(commentLikeRepository.existsByCommentIdAndUserId(commentId, userId)).thenReturn(true);
 
@@ -127,6 +127,7 @@ class CommentLikeServiceImplTest {
         when(commentLikeRepository.findByCommentIdAndUserId(commentId, userId))
             .thenReturn(Optional.of(commentLike));
         when(commentLike.getComment()).thenReturn(comment);
+        when(comment.isDeleted()).thenReturn(false);
 
         commentLikeService.unlike(commentId, userId);
 
@@ -136,13 +137,15 @@ class CommentLikeServiceImplTest {
     }
 
     @Test
-    @DisplayName("댓글 좋아요 취소 - 실패: 좋아요 존재 안함")
-    void unlike_NotLiked() {
+    @DisplayName("댓글 좋아요 취소 - 실패: 삭제된 댓글")
+    void unlike_DeletedComment() {
         when(commentLikeRepository.findByCommentIdAndUserId(commentId, userId))
-            .thenReturn(Optional.empty());
+            .thenReturn(Optional.of(commentLike));
+        when(commentLike.getComment()).thenReturn(comment);
+        when(comment.isDeleted()).thenReturn(true); // 삭제된 댓글임을 명시
 
         assertThatThrownBy(() -> commentLikeService.unlike(commentId, userId))
-            .isInstanceOf(CommentLikeNotFoundException.class)
+            .isInstanceOf(CommentNotFoundException.class)
             .hasFieldOrPropertyWithValue("errorCode.httpStatus.value", 404);
     }
 }

--- a/monew/src/test/java/com/codeit/team2/monew/module/domain/comment/service/CommentServiceImplTest.java
+++ b/monew/src/test/java/com/codeit/team2/monew/module/domain/comment/service/CommentServiceImplTest.java
@@ -157,7 +157,7 @@ class CommentServiceImplTest {
             Instant.now()
         );
 
-        when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
+        when(commentRepository.findByIdAndDeletedFalse(commentId)).thenReturn(Optional.of(comment));
         when(comment.getUser()).thenReturn(user);
         when(user.getId()).thenReturn(userId);
         when(comment.getId()).thenReturn(commentId);
@@ -171,7 +171,7 @@ class CommentServiceImplTest {
 
         // then
         assertThat(result).isEqualTo(expectedDto);
-        verify(commentRepository).findById(commentId);
+        verify(commentRepository).findByIdAndDeletedFalse(commentId);
         verify(comment).update(request.content());
         verify(commentMapper).toDto(comment, false);
     }
@@ -182,7 +182,7 @@ class CommentServiceImplTest {
         //given
         CommentUpdateRequest request = new CommentUpdateRequest("edited comment");
 
-        when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
+        when(commentRepository.findByIdAndDeletedFalse(commentId)).thenReturn(Optional.of(comment));
         when(comment.getUser()).thenReturn(user);
         when(user.getId()).thenReturn(userId);
 
@@ -197,7 +197,7 @@ class CommentServiceImplTest {
     void edit_Not_Found() {
         CommentUpdateRequest request = new CommentUpdateRequest("edited comment");
 
-        when(commentRepository.findById(commentId)).thenReturn(Optional.empty());
+        when(commentRepository.findByIdAndDeletedFalse(commentId)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> commentService.edit(commentId, userId, request))
             .isInstanceOf(CommentNotFoundException.class)
@@ -207,16 +207,13 @@ class CommentServiceImplTest {
     @Test
     @DisplayName("댓글 삭제 - 성공")
     void delete_success() {
-        //given
-        when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
+        when(commentRepository.findByIdAndDeletedFalse(commentId)).thenReturn(Optional.of(comment));
         when(comment.getUser()).thenReturn(user);
         when(user.getId()).thenReturn(userId);
 
-        //when
         commentService.delete(commentId, userId);
 
-        //then
-        verify(commentRepository).findById(commentId);
+        verify(commentRepository).findByIdAndDeletedFalse(commentId);
         verify(comment).delete();
     }
 
@@ -224,7 +221,7 @@ class CommentServiceImplTest {
     @DisplayName("댓글 삭제 - 실패: 댓글 작성자 아닐때")
     void delete_Permission_Denied() {
         //given
-        when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
+        when(commentRepository.findByIdAndDeletedFalse(commentId)).thenReturn(Optional.of(comment));
         when(comment.getUser()).thenReturn(user);
         when(user.getId()).thenReturn(userId);
 


### PR DESCRIPTION
CommentRepository에 findByIdAndDeletedFalse 메서드를 추가하여 삭제되지 않은 댓글만 조회할 수 있도록 수정했습니다.
CommentRepository의 count 관련 메서드들(countByArticleId, countByArticleIds)에 deleted = false 조건을 추가했습니다.
CommentServiceImpl.edit에서 findById를 findByIdAndDeletedFalse로 변경했습니다.
CommentLikeServiceImpl.like에서 findById를 findByIdAndDeletedFalse로 변경했습니다.

댓글 삭제 시 댓글 개수가 올바르게 감소하도록 하고, 삭제된 댓글에 대한 접근이 일관되게 거부가 되는 로직이 정삭적으로 동작하는 것을 확인하였습니다.